### PR TITLE
#21 Verify optional/mandatory fields 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: python
 python:
+  - "3.5"
   - "3.6"
 install: "pip install -r requirements.txt"
 script: python -m unittest discover tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a changelog](https://github.com/olivierlacan/keep-a-changelog).
 
 ## [Unreleased](https://github.com/idealista/prom2teams/tree/develop)
+### Fixed
+- *[#21](https://github.com/idealista/prom2teams/issues/21) Made some JSON fields optional, avoiding later crashes* @jnogol
 
 ## [1.1.2](https://github.com/idealista/prom2teams/tree/1.1.2)
 [Full Changelog](https://github.com/idealista/prom2teams/compare/1.1.1...1.1.2)

--- a/prom2teams/message/parser.py
+++ b/prom2teams/message/parser.py
@@ -4,18 +4,12 @@ import logging
 
 logger = logging.getLogger()
 
-
-def parse(json_str):
-    alert_fields = {}
-    json_values = json.loads(json_str)
-
-    json_alerts_attr = json_values['alerts'][0]
-    json_alerts_labels_attr = json_alerts_attr['labels']
-    json_alerts_annotations_attr = json_alerts_attr['annotations']
-
+def check_fields(json_alerts_attr, json_alerts_labels_attr, json_alerts_annotations_attr):
     mandatory_fields = ['alertname', 'status', 'instance', 'summary']
     optional_fields = ['severity', 'description']
     fields = mandatory_fields + optional_fields
+
+    alert_fields = {}
 
     for field in fields:
         alert_field_key = 'alert_' + field
@@ -27,8 +21,17 @@ def parse(json_str):
             alert_fields[alert_field_key] = json_alerts_annotations_attr[field]
         elif field in mandatory_fields:
             alert_fields['alert_severity'] = 'severe'
-            alert_fields['alert_summary'] = 'Incorrect JSON received. At least one mandatory field ('+field+') is absent.'
             alert_fields['alert_status'] = 'incorrect'
+            alert_fields['alert_summary'] = 'Incorrect JSON received. At least one mandatory field ('+field+') is absent.'
             return alert_fields
 
     return alert_fields
+
+def parse(json_str):
+    json_values = json.loads(json_str)
+
+    json_alerts_attr = json_values['alerts'][0]
+    json_alerts_labels_attr = json_alerts_attr['labels']
+    json_alerts_annotations_attr = json_alerts_attr['annotations']
+
+    return check_fields(json_alerts_attr, json_alerts_labels_attr, json_alerts_annotations_attr)

--- a/prom2teams/message/parser.py
+++ b/prom2teams/message/parser.py
@@ -6,19 +6,28 @@ logger = logging.getLogger()
 
 
 def parse(json_str):
-    logger.debug('received: %s', json_str)
-
+    return_dict = {}
     json_values = json.loads(json_str)
 
     json_alerts_attr = json_values['alerts'][0]
     json_alerts_labels_attr = json_alerts_attr['labels']
     json_alerts_annotations_attr = json_alerts_attr['annotations']
 
-    return {
-        'alert_name': json_alerts_labels_attr['alertname'],
-        'alert_instance': json_alerts_labels_attr['instance'],
-        'alert_severity': json_alerts_labels_attr['severity'],
-        'alert_summary': json_alerts_annotations_attr['summary'],
-        'alert_description': json_alerts_annotations_attr['description'],
-        'alert_status': json_alerts_attr['status']
-    }
+    mandatory_fields = ['alertname', 'status', 'instance', 'summary']
+    optional_fields = ['severity', 'description']
+    fields = mandatory_fields + optional_fields
+
+    for field in fields:
+        if field in json_alerts_attr:
+            return_dict['alert_'+field] = json_alerts_attr[field]
+        elif field in json_alerts_labels_attr:
+            return_dict['alert_'+field] = json_alerts_labels_attr[field]
+        elif field in json_alerts_annotations_attr:
+            return_dict['alert_'+field] = json_alerts_annotations_attr[field]
+        elif field in mandatory_fields:
+            return_dict['alert_severity'] = 'severe'
+            return_dict['alert_summary'] = 'Incorrect JSON received. At least one mandatory field ('+field+') is absent.'
+            return_dict['alert_status'] = 'incorrect'            
+            return return_dict
+
+    return return_dict

--- a/prom2teams/message/parser.py
+++ b/prom2teams/message/parser.py
@@ -19,6 +19,7 @@ def check_fields(json_alerts_attr, json_alerts_labels_attr, json_alerts_annotati
             alert_fields[alert_field_key] = json_alerts_labels_attr[field]
         elif field in json_alerts_annotations_attr:
             alert_fields[alert_field_key] = json_alerts_annotations_attr[field]
+        # If the field isn't in the JSON but it's a mandatory field, then we send an error message
         elif field in mandatory_fields:
             alert_fields['alert_severity'] = 'severe'
             alert_fields['alert_status'] = 'incorrect'

--- a/prom2teams/message/parser.py
+++ b/prom2teams/message/parser.py
@@ -6,7 +6,7 @@ logger = logging.getLogger()
 
 
 def parse(json_str):
-    return_dict = {}
+    alert_fields = {}
     json_values = json.loads(json_str)
 
     json_alerts_attr = json_values['alerts'][0]
@@ -18,16 +18,17 @@ def parse(json_str):
     fields = mandatory_fields + optional_fields
 
     for field in fields:
+        alert_field_key = 'alert_' + field
         if field in json_alerts_attr:
-            return_dict['alert_'+field] = json_alerts_attr[field]
+            alert_fields[alert_field_key] = json_alerts_attr[field]
         elif field in json_alerts_labels_attr:
-            return_dict['alert_'+field] = json_alerts_labels_attr[field]
+            alert_fields[alert_field_key] = json_alerts_labels_attr[field]
         elif field in json_alerts_annotations_attr:
-            return_dict['alert_'+field] = json_alerts_annotations_attr[field]
+            alert_fields[alert_field_key] = json_alerts_annotations_attr[field]
         elif field in mandatory_fields:
-            return_dict['alert_severity'] = 'severe'
-            return_dict['alert_summary'] = 'Incorrect JSON received. At least one mandatory field ('+field+') is absent.'
-            return_dict['alert_status'] = 'incorrect'            
-            return return_dict
+            alert_fields['alert_severity'] = 'severe'
+            alert_fields['alert_summary'] = 'Incorrect JSON received. At least one mandatory field ('+field+') is absent.'
+            alert_fields['alert_status'] = 'incorrect'
+            return alert_fields
 
-    return return_dict
+    return alert_fields

--- a/prom2teams/teams/template.j2
+++ b/prom2teams/teams/template.j2
@@ -12,35 +12,25 @@
     "@context": "http://schema.org/extensions",
     "themeColor": "{% if alert_status=='resolved' %} {{ theme_colors.resolved }} {% else %} {{ theme_colors[msg_text.alert_severity] }} {% endif %}",
     "summary": "{{ msg_text.alert_summary }}",
-    "title": "Prometheus alarm {% if alert_status=='resolved' %} (Resolved) {% endif %}",
+    "title": "Prometheus alarm {% if alert_status=='resolved' %} (Resolved) {% elif alert_status=='incorrect' %} (Incorrect) {% endif %}",
     "sections": [{
         "activityTitle": "{{ msg_text.alert_summary }}",
-        "facts": [{
-{% if msg_text.alert_alertname %}
+        "facts": [{% if msg_text.alert_alertname %}{
             "name": "Alarm",
             "value": "{{ msg_text.alert_alertname }}"
-        }, {
-{% endif %}
-{% if msg_text.alert_instance %}
+        },{% endif %}{% if msg_text.alert_instance %}{
             "name": "In host",
             "value": "{{ msg_text.alert_instance }}"
-        }, {
-{% endif %}
-{% if msg_text.alert_severity %}
+        },{% endif %}{% if msg_text.alert_severity %}{
             "name": "Severity",
             "value": "{{ msg_text.alert_severity }}"
-        }, {
-{% endif %}
-{% if msg_text.alert_description %}
+        },{% endif %}{% if msg_text.alert_description %}{
             "name": "Description",
             "value": "{{ msg_text.alert_description }}"
-        }, {
-{% endif %}
-{% if msg_text.alert_status %}
+        },{% endif %}{
             "name": "Status",
             "value": "{{ msg_text.alert_status }}"
-{% endif %}
         }],
            "markdown": true
-        }]
+    }]
 }

--- a/prom2teams/teams/template.j2
+++ b/prom2teams/teams/template.j2
@@ -16,20 +16,30 @@
     "sections": [{
         "activityTitle": "{{ msg_text.alert_summary }}",
         "facts": [{
+{% if msg_text.alert_alertname %}
             "name": "Alarm",
-            "value": "{{ msg_text.alert_name }}"
+            "value": "{{ msg_text.alert_alertname }}"
         }, {
+{% endif %}
+{% if msg_text.alert_instance %}
             "name": "In host",
             "value": "{{ msg_text.alert_instance }}"
         }, {
+{% endif %}
+{% if msg_text.alert_severity %}
             "name": "Severity",
             "value": "{{ msg_text.alert_severity }}"
         }, {
+{% endif %}
+{% if msg_text.alert_description %}
             "name": "Description",
             "value": "{{ msg_text.alert_description }}"
         }, {
+{% endif %}
+{% if msg_text.alert_status %}
             "name": "Status",
             "value": "{{ msg_text.alert_status }}"
+{% endif %}
         }],
            "markdown": true
         }]

--- a/tests/context.py
+++ b/tests/context.py
@@ -4,3 +4,4 @@ import sys
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../prom2teams')))
 
 from prom2teams import server, exceptions
+from prom2teams.message.parser import parse

--- a/tests/data/jsons/all_ok.json
+++ b/tests/data/jsons/all_ok.json
@@ -1,0 +1,27 @@
+{
+  "receiver": "test_webhook",
+  "status": "resolved",
+  "alerts": [
+    {
+      "status": "resolved",
+      "labels": {
+        "alertname": "DiskSpace",
+        "device": "rootfs",
+        "fstype": "rootfs",
+        "instance": "cs30.evilcorp",
+        "job": "fsociety",
+        "mountpoint": "/",
+        "severity": "severe"
+      },
+      "annotations": {
+        "description": "disk usage 73% on rootfs device",
+        "summary": "Disk usage alert on CS30.evilcorp"
+      },
+      "startsAt": "2017-05-09T07:01:37.803Z",
+      "endsAt": "2017-05-09T07:08:37.818278068Z",
+      "generatorURL": "my.prometheusserver.url"
+    }
+  ],
+  "externalURL": "my.prometheusalertmanager.url",
+  "version": "4"
+}

--- a/tests/data/jsons/without_mandatory_field.json
+++ b/tests/data/jsons/without_mandatory_field.json
@@ -1,0 +1,25 @@
+{
+  "receiver": "test_webhook",
+  "alerts": [
+    {
+      "labels": {
+        "alertname": "DiskSpace",
+        "device": "rootfs",
+        "fstype": "rootfs",
+        "instance": "cs30.evilcorp",
+        "job": "fsociety",
+        "mountpoint": "/",
+        "severity": "severe"
+      },
+      "annotations": {
+        "description": "disk usage 73% on rootfs device",
+        "summary": "Disk usage alert on CS30.evilcorp"
+      },
+      "startsAt": "2017-05-09T07:01:37.803Z",
+      "endsAt": "2017-05-09T07:08:37.818278068Z",
+      "generatorURL": "my.prometheusserver.url"
+    }
+  ],
+  "externalURL": "my.prometheusalertmanager.url",
+  "version": "4"
+}

--- a/tests/data/jsons/without_optional_field.json
+++ b/tests/data/jsons/without_optional_field.json
@@ -1,0 +1,26 @@
+{
+  "receiver": "test_webhook",
+  "status": "resolved",
+  "alerts": [
+    {
+      "status": "resolved",
+      "labels": {
+        "alertname": "DiskSpace",
+        "device": "rootfs",
+        "fstype": "rootfs",
+        "instance": "cs30.evilcorp",
+        "job": "fsociety",
+        "mountpoint": "/",
+        "severity": "severe"
+      },
+      "annotations": {
+        "summary": "Disk usage alert on CS30.evilcorp"
+      },
+      "startsAt": "2017-05-09T07:01:37.803Z",
+      "endsAt": "2017-05-09T07:08:37.818278068Z",
+      "generatorURL": "my.prometheusserver.url"
+    }
+  ],
+  "externalURL": "my.prometheusalertmanager.url",
+  "version": "4"
+}

--- a/tests/test_json_fields.py
+++ b/tests/test_json_fields.py
@@ -6,22 +6,22 @@ from context import parse
 
 class TestServer(unittest.TestCase):
 
-    TEST_CONFIG_FILES_PATH = 'tests/data/'
+    TEST_CONFIG_FILES_PATH = 'tests/data/jsons'
 
     def test_json_with_all_fields(self):
-        with open(self.TEST_CONFIG_FILES_PATH + 'jsons/all_ok.json') as json_data:
+        with open(self.TEST_CONFIG_FILES_PATH + 'all_ok.json') as json_data:
             json_received = json.load(json_data)
             alert_fields = parse(json.dumps(json_received))
             self.assertNotIn('Incorrect',str(alert_fields))
 
     def test_json_without_mandatory_field(self):
-        with open(self.TEST_CONFIG_FILES_PATH + 'jsons/without_mandatory_field.json') as json_data:
+        with open(self.TEST_CONFIG_FILES_PATH + 'without_mandatory_field.json') as json_data:
             json_received = json.load(json_data)
             alert_fields = parse(json.dumps(json_received))
             self.assertIn('Incorrect',str(alert_fields))
 
     def test_json_without_optional_field(self):
-        with open(self.TEST_CONFIG_FILES_PATH + 'jsons/without_optional_field.json') as json_data:
+        with open(self.TEST_CONFIG_FILES_PATH + 'without_optional_field.json') as json_data:
             json_received = json.load(json_data)
             alert_fields = parse(json.dumps(json_received))
             self.assertNotIn('Incorrect',str(alert_fields))

--- a/tests/test_json_fields.py
+++ b/tests/test_json_fields.py
@@ -1,0 +1,31 @@
+import unittest
+import json
+
+from context import parse
+
+
+class TestServer(unittest.TestCase):
+
+    TEST_CONFIG_FILES_PATH = 'tests/data/'
+
+    def test_json_with_all_fields(self):
+        with open(self.TEST_CONFIG_FILES_PATH + 'jsons/all_ok.json') as json_data:
+            json_received = json.load(json_data)
+            alert_fields = parse(json.dumps(json_received))
+            self.assertNotIn('Incorrect',str(alert_fields))
+
+    def test_json_without_mandatory_field(self):
+        with open(self.TEST_CONFIG_FILES_PATH + 'jsons/without_mandatory_field.json') as json_data:
+            json_received = json.load(json_data)
+            alert_fields = parse(json.dumps(json_received))
+            self.assertIn('Incorrect',str(alert_fields))
+
+    def test_json_without_optional_field(self):
+        with open(self.TEST_CONFIG_FILES_PATH + 'jsons/without_optional_field.json') as json_data:
+            json_received = json.load(json_data)
+            alert_fields = parse(json.dumps(json_received))
+            self.assertNotIn('Incorrect',str(alert_fields))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_json_fields.py
+++ b/tests/test_json_fields.py
@@ -4,7 +4,7 @@ import json
 from context import parse
 
 
-class TestServer(unittest.TestCase):
+class TestJSONFields(unittest.TestCase):
 
     TEST_CONFIG_FILES_PATH = 'tests/data/jsons/'
 

--- a/tests/test_json_fields.py
+++ b/tests/test_json_fields.py
@@ -6,7 +6,7 @@ from context import parse
 
 class TestServer(unittest.TestCase):
 
-    TEST_CONFIG_FILES_PATH = 'tests/data/jsons'
+    TEST_CONFIG_FILES_PATH = 'tests/data/jsons/'
 
     def test_json_with_all_fields(self):
         with open(self.TEST_CONFIG_FILES_PATH + 'all_ok.json') as json_data:


### PR DESCRIPTION
- Changed `alertname` to `alert_alertname` (to make it easier to loop over it).
- Now we have two lists with the mandatory and optional fields.
- In case one mandatory field is missing, it will send an error message to Microsoft Teams