### PR TITLE
Features/pypi travis integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: python
 python:
-- "3.5"
-- "3.6"
+  - "3.5"
+  - "3.6"
 before_install:
   - sudo apt-get install -y pandoc
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,13 @@ language: python
 python:
 - "3.5"
 - "3.6"
+before_install:
+  - sudo apt-get install -y pandoc
 install: "pip install -r requirements.txt"
 script: python -m unittest discover tests
 deploy:
   provider: pypi
-  server: https://testpypi.python.org/pypi
+  server: https://test.pypi.org/legacy/
   on:
     all_branches: true
   user: "idealista"

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,13 +4,12 @@ python:
 - "3.6"
 before_install:
   - sudo apt-get install -y pandoc
-install: "pip install -r requirements.txt"
-script: python -m unittest discover tests
+install:
+  - pip install -r requirements.txt
+script:
+  - python -m unittest discover tests
 deploy:
   provider: pypi
-  server: https://test.pypi.org/legacy/
-  on:
-    all_branches: true
-  user: "dortega"
+  user: "idealista"
   password:
     secure: L80/PUp/eGj6+OPzGfv0vO5V+5V5dIuaw4qRHlVDgEsZaFlJPsEL62x8CYv6DXewaYIBKhMk2cXWMkHuWFKjTcJ+Vjsqx6jIUwBLI48eKAWMxEP3ypJf3gqLeJmYFO6QPUGu1pOuOiFjBeV+yXNz7+C7ZY04cAcvgBGgRs+Tw6Se+AgfWNFXZZDX7N9/eWzFktqRpisWLNUJBBl6JnRcYhiadD5PvqS8eTsI/hiewMWijzlbfzZJ4PEFLJ7g2r3LL2OgHp1FR4zliXo0tMtFSyCFHAYz7vIcGDVlp1GmPSD0Me9h+LnjArK1LwotSA6DdwIVVrS+/ZR3ocHETbUxROrHLLZMN+tE6gcJ+ANq4HTqt4r7WVGO10IOYLqaZmNxazoyYilJRORvpYd6CUpR+8pNybG54YrR4qc4FBoWTob8T1+BGUN6K/R1M2vgZC6adlMmNguNMJ/wX5GzBO7nUju6TcehYJfZQGc3WYQuV/WpE1IHMJSJJwMwAkvJ7yiEM5nj5WDLsrPU6ViBc/konM1Bl/loZ7YhyaKtr9ypqMxkHsnECpAt3gI2Btu4Az8JQd3ZqHgmTmI399E4k1qoRgv0zPjFDDzOM7QB5Q7YZ0jzRBJqFlaII2wZC3iNHfxWSW/bjq9OOwwQkuti/WeyqG2XHg8gwpyixUUqLUw9Wy8=

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,6 @@ deploy:
   server: https://test.pypi.org/legacy/
   on:
     all_branches: true
-  user: "idealista"
+  user: "dortega"
   password:
     secure: L80/PUp/eGj6+OPzGfv0vO5V+5V5dIuaw4qRHlVDgEsZaFlJPsEL62x8CYv6DXewaYIBKhMk2cXWMkHuWFKjTcJ+Vjsqx6jIUwBLI48eKAWMxEP3ypJf3gqLeJmYFO6QPUGu1pOuOiFjBeV+yXNz7+C7ZY04cAcvgBGgRs+Tw6Se+AgfWNFXZZDX7N9/eWzFktqRpisWLNUJBBl6JnRcYhiadD5PvqS8eTsI/hiewMWijzlbfzZJ4PEFLJ7g2r3LL2OgHp1FR4zliXo0tMtFSyCFHAYz7vIcGDVlp1GmPSD0Me9h+LnjArK1LwotSA6DdwIVVrS+/ZR3ocHETbUxROrHLLZMN+tE6gcJ+ANq4HTqt4r7WVGO10IOYLqaZmNxazoyYilJRORvpYd6CUpR+8pNybG54YrR4qc4FBoWTob8T1+BGUN6K/R1M2vgZC6adlMmNguNMJ/wX5GzBO7nUju6TcehYJfZQGc3WYQuV/WpE1IHMJSJJwMwAkvJ7yiEM5nj5WDLsrPU6ViBc/konM1Bl/loZ7YhyaKtr9ypqMxkHsnECpAt3gI2Btu4Az8JQd3ZqHgmTmI399E4k1qoRgv0zPjFDDzOM7QB5Q7YZ0jzRBJqFlaII2wZC3iNHfxWSW/bjq9OOwwQkuti/WeyqG2XHg8gwpyixUUqLUw9Wy8=

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,14 @@
 language: python
 python:
-- '3.5'
-- '3.6'
+- "3.5"
+- "3.6"
 install: "pip install -r requirements.txt"
 script: python -m unittest discover tests
 deploy:
   provider: pypi
+  server: https://testpypi.python.org/pypi
+  on:
+    all_branches: true
   user: "idealista"
   password:
     secure: L80/PUp/eGj6+OPzGfv0vO5V+5V5dIuaw4qRHlVDgEsZaFlJPsEL62x8CYv6DXewaYIBKhMk2cXWMkHuWFKjTcJ+Vjsqx6jIUwBLI48eKAWMxEP3ypJf3gqLeJmYFO6QPUGu1pOuOiFjBeV+yXNz7+C7ZY04cAcvgBGgRs+Tw6Se+AgfWNFXZZDX7N9/eWzFktqRpisWLNUJBBl6JnRcYhiadD5PvqS8eTsI/hiewMWijzlbfzZJ4PEFLJ7g2r3LL2OgHp1FR4zliXo0tMtFSyCFHAYz7vIcGDVlp1GmPSD0Me9h+LnjArK1LwotSA6DdwIVVrS+/ZR3ocHETbUxROrHLLZMN+tE6gcJ+ANq4HTqt4r7WVGO10IOYLqaZmNxazoyYilJRORvpYd6CUpR+8pNybG54YrR4qc4FBoWTob8T1+BGUN6K/R1M2vgZC6adlMmNguNMJ/wX5GzBO7nUju6TcehYJfZQGc3WYQuV/WpE1IHMJSJJwMwAkvJ7yiEM5nj5WDLsrPU6ViBc/konM1Bl/loZ7YhyaKtr9ypqMxkHsnECpAt3gI2Btu4Az8JQd3ZqHgmTmI399E4k1qoRgv0zPjFDDzOM7QB5Q7YZ0jzRBJqFlaII2wZC3iNHfxWSW/bjq9OOwwQkuti/WeyqG2XHg8gwpyixUUqLUw9Wy8=

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,11 @@
 language: python
 python:
-  - "3.5"
-  - "3.6"
+- '3.5'
+- '3.6'
 install: "pip install -r requirements.txt"
 script: python -m unittest discover tests
+deploy:
+  provider: pypi
+  user: "idealista"
+  password:
+    secure: L80/PUp/eGj6+OPzGfv0vO5V+5V5dIuaw4qRHlVDgEsZaFlJPsEL62x8CYv6DXewaYIBKhMk2cXWMkHuWFKjTcJ+Vjsqx6jIUwBLI48eKAWMxEP3ypJf3gqLeJmYFO6QPUGu1pOuOiFjBeV+yXNz7+C7ZY04cAcvgBGgRs+Tw6Se+AgfWNFXZZDX7N9/eWzFktqRpisWLNUJBBl6JnRcYhiadD5PvqS8eTsI/hiewMWijzlbfzZJ4PEFLJ7g2r3LL2OgHp1FR4zliXo0tMtFSyCFHAYz7vIcGDVlp1GmPSD0Me9h+LnjArK1LwotSA6DdwIVVrS+/ZR3ocHETbUxROrHLLZMN+tE6gcJ+ANq4HTqt4r7WVGO10IOYLqaZmNxazoyYilJRORvpYd6CUpR+8pNybG54YrR4qc4FBoWTob8T1+BGUN6K/R1M2vgZC6adlMmNguNMJ/wX5GzBO7nUju6TcehYJfZQGc3WYQuV/WpE1IHMJSJJwMwAkvJ7yiEM5nj5WDLsrPU6ViBc/konM1Bl/loZ7YhyaKtr9ypqMxkHsnECpAt3gI2Btu4Az8JQd3ZqHgmTmI399E4k1qoRgv0zPjFDDzOM7QB5Q7YZ0jzRBJqFlaII2wZC3iNHfxWSW/bjq9OOwwQkuti/WeyqG2XHg8gwpyixUUqLUw9Wy8=

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ with open('LICENSE') as f:
 
 
 setup(name='prom2teams',
-      version='1.1.2',
+      version='1.1.3',
       description='Project that redirects Prometheus Alert Manager '
       'notifications to Microsoft Teams',
       long_description=readme,

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ with open('LICENSE') as f:
 
 
 setup(name='prom2teams',
-      version='1.1.3',
+      version='1.1.21',
       description='Project that redirects Prometheus Alert Manager '
       'notifications to Microsoft Teams',
       long_description=readme,

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ with open('LICENSE') as f:
 
 
 setup(name='prom2teams',
-      version='1.1.21',
+      version='1.1.3',
       description='Project that redirects Prometheus Alert Manager '
       'notifications to Microsoft Teams',
       long_description=readme,


### PR DESCRIPTION
Add Travis -> PyPi continuous integration. Will only trigger the PyPi deployment after we release a new version of the `master` branch (according to Travis Documentation).

Plus, `develop` is now protected, so I'm increasing the version now to 1.1.3 to release the changes made for #21 