### PR TITLE
Set a default value of 'none' to instance attribute in alerts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a ch
 
 ## [Unreleased](https://github.com/idealista/prom2teams/tree/develop)
 
+### Added
+
+- *[#32]((https://github.com/idealista/prom2teams/issues/32) Sets default value for "instance" in alerts* @maglo
+
 ## [1.1.3](https://github.com/idealista/prom2teams/tree/1.1.3)
 [Full Changelog](https://github.com/idealista/prom2teams/compare/1.1.2...1.1.3)
 ### Fixed

--- a/prom2teams/message/parser.py
+++ b/prom2teams/message/parser.py
@@ -5,11 +5,14 @@ import logging
 logger = logging.getLogger()
 
 def check_fields(json_alerts_attr, json_alerts_labels_attr, json_alerts_annotations_attr):
-    mandatory_fields = ['alertname', 'status', 'instance', 'summary']
-    optional_fields = ['severity', 'description']
+    mandatory_fields = ['alertname', 'status', 'summary']
+    optional_fields = ['severity', 'description', 'instance']
     fields = mandatory_fields + optional_fields
 
     alert_fields = {}
+    
+    # Set the instance to 'none' by default. 
+    alert_fields['alert_instance'] = 'none'
 
     for field in fields:
         alert_field_key = 'alert_' + field

--- a/tests/data/jsons/without_instance_field.json
+++ b/tests/data/jsons/without_instance_field.json
@@ -1,0 +1,25 @@
+{
+  "receiver": "test_webhook",
+  "status": "resolved",
+  "alerts": [
+    {
+      "status": "resolved",
+      "labels": {
+        "alertname": "DiskSpace",
+        "device": "rootfs",
+        "fstype": "rootfs",
+        "job": "fsociety",
+        "mountpoint": "/",
+        "severity": "severe"
+      },
+      "annotations": {
+        "summary": "Disk usage alert on CS30.evilcorp"
+      },
+      "startsAt": "2017-05-09T07:01:37.803Z",
+      "endsAt": "2017-05-09T07:08:37.818278068Z",
+      "generatorURL": "my.prometheusserver.url"
+    }
+  ],
+  "externalURL": "my.prometheusalertmanager.url",
+  "version": "4"
+}

--- a/tests/test_json_fields.py
+++ b/tests/test_json_fields.py
@@ -26,6 +26,11 @@ class TestJSONFields(unittest.TestCase):
             alert_fields = parse(json.dumps(json_received))
             self.assertNotIn('Incorrect',str(alert_fields))
 
+    def test_json_without_instance_field(self):
+        with open(self.TEST_CONFIG_FILES_PATH + 'without_instance_field.json') as json_data:
+            json_received = json.load(json_data)
+            alert_fields = parse(json.dumps(json_received))
+            self.assertEqual('none',str(alert_fields['alarm_0']['alert_instance']))
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
### Description of the Change

Set a default value of 'none' to instance attribute in alerts

Sometimes, an alert is generated without an instance.
For example if an alert is triggered when none of the monitored
instances has a particular property, such as the case when a vital
container is *not* running on any instance.
 
In this case, it makes sense to set the value of the `instance`
property to `none`, since it did not originate from a particular
instance.
    
This PR changes `intance` to an optional field, and sets a default value
 to `none`.

### Benefits

An alert will be properly forwarded if the alert does not contain a reference to an instance.

It will be clear to the user that there is no particular instance that caused the alert, since `instance` displays `none`.

### Possible Drawbacks

- N/A

### Applicable Issues

- #32