### PR TITLE
All mandatory fields now have default values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a changelog](https://github.com/olivierlacan/keep-a-changelog).
 
 ## [Unreleased](https://github.com/idealista/prom2teams/tree/develop)
+- *[#32](https://github.com/idealista/prom2teams/issues/32) Support alerts with missing mandatory attributes @lindhor
 
 ## [1.2.0](https://github.com/idealista/prom2teams/tree/1.2.0)
 [Full Changelog](https://github.com/idealista/prom2teams/compare/1.1.3...1.2.0)

--- a/README.md
+++ b/README.md
@@ -80,6 +80,11 @@ url: 0.0.0.0:8089
 
 prom2teams provides a [default template](app/teams/template.j2) built with [Jinja2](http://jinja.pocoo.org/docs/2.9/) to render messages in Microsoft Teams. This template could be overrided using the 'templatepath' argument ('--templatepath <Jinja2 template file path>') during the application start.
 
+Some fields are considered mandatory when received from Alert Manager.
+If such a field is not included a default value of 'unknown' is assigned as described below:
+
+Other optional fields are skipped and not included in the Teams message.
+
 ## Testing
 
 To run the test suite you should type the following:

--- a/prom2teams/message/parser.py
+++ b/prom2teams/message/parser.py
@@ -5,15 +5,12 @@ import logging
 logger = logging.getLogger()
 
 def check_fields(json_alerts_attr, json_alerts_labels_attr, json_alerts_annotations_attr):
-    mandatory_fields = ['alertname', 'status', 'summary']
-    optional_fields = ['severity', 'description', 'instance']
+    mandatory_fields = ['alertname', 'status', 'instance', 'summary']
+    optional_fields = ['severity', 'description']
     fields = mandatory_fields + optional_fields
 
     alert_fields = {}
     
-    # Set the instance to 'none' by default. 
-    alert_fields['alert_instance'] = 'none'
-
     for field in fields:
         alert_field_key = 'alert_' + field
         if field in json_alerts_attr:
@@ -22,13 +19,12 @@ def check_fields(json_alerts_attr, json_alerts_labels_attr, json_alerts_annotati
             alert_fields[alert_field_key] = json_alerts_labels_attr[field]
         elif field in json_alerts_annotations_attr:
             alert_fields[alert_field_key] = json_alerts_annotations_attr[field]
-        # If the field isn't in the JSON but it's a mandatory field, then we send an error message
+        # If the field isn't in the JSON but it's a mandatory field, then we use default values
         elif field in mandatory_fields:
-            alert_fields['alert_severity'] = 'severe'
-            alert_fields['alert_status'] = 'incorrect'
-            alert_fields['alert_summary'] = 'Incorrect JSON received. At least one mandatory field ('+field+') is absent.'
-            return alert_fields
-
+            if field in json_alerts_attr:
+                alert_fields[alert_field_key] = json_alerts_attr[field]
+            else:
+                alert_fields[alert_field_key] = 'unknown'
     return alert_fields
 
 def parse(json_str):

--- a/prom2teams/teams/template.j2
+++ b/prom2teams/teams/template.j2
@@ -3,7 +3,8 @@
     'resolved' : '2DC72D',
     'critical' : '8C1A1A',
     'severe' : '8C1A1A',
-    'warning' : 'FF9A0B'
+    'warning' : 'FF9A0B',
+    'unknown' : 'CCCCCC'
   }
 -%}
 
@@ -12,7 +13,7 @@
     "@context": "http://schema.org/extensions",
     "themeColor": "{% if alert_status=='resolved' %} {{ theme_colors.resolved }} {% else %} {{ theme_colors[msg_text.alert_severity] }} {% endif %}",
     "summary": "{{ msg_text.alert_summary }}",
-    "title": "Prometheus alarm {% if alert_status=='resolved' %} (Resolved) {% elif alert_status=='incorrect' %} (Incorrect) {% endif %}",
+    "title": "Prometheus alarm {% if alert_status=='resolved' %} (Resolved) {% elif alert_status=='unknown' %} (status unknown) {% endif %}",
     "sections": [{
         "activityTitle": "{{ msg_text.alert_summary }}",
         "facts": [{% if msg_text.alert_alertname %}{

--- a/tests/data/jsons/without_mandatory_field.json
+++ b/tests/data/jsons/without_mandatory_field.json
@@ -3,17 +3,13 @@
   "alerts": [
     {
       "labels": {
-        "alertname": "DiskSpace",
         "device": "rootfs",
         "fstype": "rootfs",
-        "instance": "cs30.evilcorp",
         "job": "fsociety",
-        "mountpoint": "/",
-        "severity": "severe"
+        "mountpoint": "/"
       },
       "annotations": {
-        "description": "disk usage 73% on rootfs device",
-        "summary": "Disk usage alert on CS30.evilcorp"
+        "description": "disk usage 73% on rootfs device"
       },
       "startsAt": "2017-05-09T07:01:37.803Z",
       "endsAt": "2017-05-09T07:08:37.818278068Z",

--- a/tests/test_json_fields.py
+++ b/tests/test_json_fields.py
@@ -12,25 +12,25 @@ class TestJSONFields(unittest.TestCase):
         with open(self.TEST_CONFIG_FILES_PATH + 'all_ok.json') as json_data:
             json_received = json.load(json_data)
             alert_fields = parse(json.dumps(json_received))
-            self.assertNotIn('Incorrect',str(alert_fields))
+            self.assertNotIn('unknown',str(alert_fields))
 
     def test_json_without_mandatory_field(self):
         with open(self.TEST_CONFIG_FILES_PATH + 'without_mandatory_field.json') as json_data:
             json_received = json.load(json_data)
             alert_fields = parse(json.dumps(json_received))
-            self.assertIn('Incorrect',str(alert_fields))
+            self.assertIn('unknown',str(alert_fields))
 
     def test_json_without_optional_field(self):
         with open(self.TEST_CONFIG_FILES_PATH + 'without_optional_field.json') as json_data:
             json_received = json.load(json_data)
             alert_fields = parse(json.dumps(json_received))
-            self.assertNotIn('Incorrect',str(alert_fields))
+            self.assertNotIn('unknown',str(alert_fields))
 
     def test_json_without_instance_field(self):
         with open(self.TEST_CONFIG_FILES_PATH + 'without_instance_field.json') as json_data:
             json_received = json.load(json_data)
             alert_fields = parse(json.dumps(json_received))
-            self.assertEqual('none',str(alert_fields['alarm_0']['alert_instance']))
+            self.assertEqual('unknown',str(alert_fields['alarm_0']['alert_instance']))
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
### Description of the Change

All mandatory fields now are set to 'unknown' if not provided by Alert Manager.
Test files are updated to verify the change.

Note that this improves upon https://github.com/idealista/prom2teams/pull/33 which only handles missing instance (created by a colleague).

### Benefits

All alerts received will be sent to MS Teams even if some fields are not provided.

### Possible Drawbacks

None

### Applicable Issues

#32 

Also see the MR 