### PR TITLE
Default summary to alertname if not provided

### DIFF
--- a/prom2teams/message/parser.py
+++ b/prom2teams/message/parser.py
@@ -5,8 +5,8 @@ import logging
 logger = logging.getLogger()
 
 def check_fields(json_alerts_attr, json_alerts_labels_attr, json_alerts_annotations_attr):
-    mandatory_fields = ['alertname', 'status', 'summary']
-    optional_fields = ['severity', 'description', 'instance']
+    mandatory_fields = ['alertname', 'status']
+    optional_fields = ['severity', 'summary', 'description', 'instance']
     fields = mandatory_fields + optional_fields
 
     alert_fields = {}
@@ -28,6 +28,9 @@ def check_fields(json_alerts_attr, json_alerts_labels_attr, json_alerts_annotati
             alert_fields['alert_status'] = 'incorrect'
             alert_fields['alert_summary'] = 'Incorrect JSON received. At least one mandatory field ('+field+') is absent.'
             return alert_fields
+
+    if alert_fields.get('alert_summary') == None:
+        alert_fields['alert_summary'] = alert_fields['alert_alertname']
 
     return alert_fields
 

--- a/tests/data/jsons/without_summary_field.json
+++ b/tests/data/jsons/without_summary_field.json
@@ -1,0 +1,26 @@
+{
+  "receiver": "test_webhook",
+  "status": "resolved",
+  "alerts": [
+    {
+      "status": "resolved",
+      "labels": {
+        "alertname": "DiskSpace",
+        "device": "rootfs",
+        "fstype": "rootfs",
+        "instance": "cs30.evilcorp",
+        "job": "fsociety",
+        "mountpoint": "/",
+        "severity": "severe"
+      },
+      "annotations": {
+        "description": "disk usage 73% on rootfs device"
+      },
+      "startsAt": "2017-05-09T07:01:37.803Z",
+      "endsAt": "2017-05-09T07:08:37.818278068Z",
+      "generatorURL": "my.prometheusserver.url"
+    }
+  ],
+  "externalURL": "my.prometheusalertmanager.url",
+  "version": "4"
+}

--- a/tests/test_json_fields.py
+++ b/tests/test_json_fields.py
@@ -3,7 +3,6 @@ import json
 
 from context import parse
 
-
 class TestJSONFields(unittest.TestCase):
 
     TEST_CONFIG_FILES_PATH = 'tests/data/jsons/'
@@ -31,6 +30,13 @@ class TestJSONFields(unittest.TestCase):
             json_received = json.load(json_data)
             alert_fields = parse(json.dumps(json_received))
             self.assertEqual('none',str(alert_fields['alarm_0']['alert_instance']))
+
+    def test_json_without_summary_field(self):
+        with open(self.TEST_CONFIG_FILES_PATH + 'without_summary_field.json') as json_data:
+            json_received = json.load(json_data)
+            alert_fields = parse(json.dumps(json_received))
+            self.assertNotIn('Incorrect',str(alert_fields))
+            self.assertEqual(alert_fields['alarm_0']['alert_alertname'],alert_fields['alarm_0']['alert_summary'])
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
### Description of the Change
Default summary field to alertname if not set

### Benefits
I have some prometheus rules that shipped from coreos without summaries set.  I'd prefer to not have to modify out of the box rules. I would assert that defaulting the summary to the alertname should be sufficient when not set.

Example rules:
https://github.com/coreos/prometheus-operator/blob/e938e44688fc4dffdf8bc19cbb9efc7b6d062847/contrib/kube-prometheus/assets/prometheus/rules/kube-state-metrics.rules.yaml#L53


