### PR TITLE
#61: Fix getting 404 (SERVER_NAME removed from flask app)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a changelog](https://github.com/olivierlacan/keep-a-changelog).
 
 ## [Unreleased](https://github.com/idealista/prom2teams/tree/develop)
+- *[#61](https://github.com/idealista/prom2teams/pull/63) Fix getting 404 errors - SERVER_NAME removed from flask app* @Gkrlo
+
 
 ## [2.0.2](https://github.com/idealista/prom2teams/tree/2.0.2)
 [Full Changelog](https://github.com/idealista/prom2teams/compare/2.0.1...2.0.2)

--- a/bin/wsgi.py
+++ b/bin/wsgi.py
@@ -11,5 +11,5 @@ except ImportError:
 
 if __name__ == "__main__":
     host = application.config['HOST']
-    port = application.config['PORT']
+    port = int(application.config['PORT'])
     application.run(host=host, port=port)

--- a/prom2teams/app/api.py
+++ b/prom2teams/app/api.py
@@ -30,4 +30,4 @@ def init_app(application):
 
 
 init_app(app)
-log.info(app.config['APP_NAME'] + ' started on ' + app.config['SERVER_NAME'])
+log.info('{} started on {}:{}'.format(app.config['APP_NAME'], app.config['HOST'], app.config['PORT']))

--- a/prom2teams/app/configuration.py
+++ b/prom2teams/app/configuration.py
@@ -34,17 +34,12 @@ def _update_application_configuration(application, configuration):
     if 'Log' in configuration and 'Path' in configuration['Log']:
         application.config['LOG_FILE_PATH'] = configuration['Log']['Path']
     if 'HTTP Server' in configuration:
-        _host, _port = application.config['SERVER_NAME'].split(':', 1)
         if 'Host' in configuration['HTTP Server']:
             _host = configuration['HTTP Server']['Host']
             application.config['HOST'] = _host
         if 'Port' in configuration['HTTP Server']:
             _port = configuration['HTTP Server']['Port']
             application.config['PORT'] = _port
-        if 'Name' in configuration['HTTP Server']:
-            application.config['SERVER_NAME'] = configuration['HTTP Server']['Name']
-        else:
-            application.config['SERVER_NAME'] = _host + ':' + _port
 
 
 def _config_provided(filepath):

--- a/prom2teams/config/settings.py
+++ b/prom2teams/config/settings.py
@@ -3,7 +3,6 @@ HOST = 'localhost'
 PORT = 8089
 # Flask settings
 DEBUG = False
-SERVER_NAME = 'localhost:8089'
 
 # Flask-Restplus settings
 SWAGGER_UI_DOC_EXPANSION = 'list'


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions
* Remember to set **idealista:develop** as base branch;

### Description of the Change
- SERVER_NAME removed from flask app.
- Casting the PORT to INT in the wsgi.py

### Benefits
404 errors avoided using the docker image

### Possible Drawbacks

### Applicable Issues
#61 
#62 
