### PR TITLE
always group by status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a ch
 
 ## [Unreleased](https://github.com/idealista/prom2teams/tree/develop)
 
+## Added
+- *[#94](https://github.com/idealista/prom2teams/pull/94) Always group by status @manuhortet*
+
 ## [2.2.1](https://github.com/idealista/prom2teams/tree/2.2.1)
 [Full Changelog](https://github.com/idealista/prom2teams/compare/2.1.2...2.2.1)
 ## Added

--- a/README.md
+++ b/README.md
@@ -51,13 +51,13 @@ $ prom2teams [--configpath <config file path>] [--groupalertsby ("name"|"descrip
 # To show the help message:
 $ prom2teams --help
 ```
-
-Another options to start the service are:
+Other options to start the service are:
 
 ```bash
 export APP_CONFIG_FILE=<config file path>
 $ prom2teams
 ```
+**Note:** Grouping alerts only works since v2.2.0
 
 ### Docker image
 
@@ -135,6 +135,7 @@ Path: <Jinja2 template path> # default: app resources template
 [Group Alerts]
 Field: <Field to group alerts by> # alerts won't be grouped by default
 ```
+**Note:** Grouping alerts only works since v2.2.0
 
 ### Configuring Prometheus
 

--- a/prom2teams/teams/alarm_mapper.py
+++ b/prom2teams/teams/alarm_mapper.py
@@ -9,31 +9,35 @@ def map_alarm_to_json(alarm):
 
 
 def map_prom_alerts_to_teams_alarms(alerts):
+    alerts = group_alerts(alerts, 'status')
     teams_alarms = []
     schema = TeamsAlarmSchema()
-    for alert in alerts:
-        alarm = TeamsAlarm(alert.name, alert.status.lower(), alert.severity,
-                           alert.summary, alert.instance, alert.description)
-        json_alarm = schema.dump(alarm).data
-        teams_alarms.append(json_alarm)
+    for same_status_alerts in alerts:
+        for alert in alerts[same_status_alerts]:
+            alarm = TeamsAlarm(alert.name, alert.status.lower(), alert.severity,
+                               alert.summary, alert.instance, alert.description)
+            json_alarm = schema.dump(alarm).data
+            teams_alarms.append(json_alarm)
     return teams_alarms
 
 
 def map_and_group(alerts, group_alerts_by):
+    alerts = group_alerts(alerts, 'status')
     teams_alarms = []
     schema = TeamsAlarmSchema()
-    grouped_alerts = group_alerts(alerts, group_alerts_by)
-    for alert in grouped_alerts:
-        features = group_features(grouped_alerts[alert])
-        name, description, instance, severity, status, summary = (teams_visualization(features["name"]),
-                                                                  teams_visualization(features["description"]),
-                                                                  teams_visualization(features["instance"]),
-                                                                  teams_visualization(features["severity"]),
-                                                                  teams_visualization(features["status"]),
-                                                                  teams_visualization(features["summary"]))
-        alarm = TeamsAlarm(name, status.lower(), severity, summary, instance, description)
-        json_alarm = schema.dump(alarm).data
-        teams_alarms.append(json_alarm)
+    for same_status_alerts in alerts:
+        grouped_alerts = group_alerts(alerts[same_status_alerts], group_alerts_by)
+        for alert in grouped_alerts:
+            features = group_features(grouped_alerts[alert])
+            name, description, instance, severity, status, summary = (teams_visualization(features["name"]),
+                                                                      teams_visualization(features["description"]),
+                                                                      teams_visualization(features["instance"]),
+                                                                      teams_visualization(features["severity"]),
+                                                                      teams_visualization(features["status"]),
+                                                                      teams_visualization(features["summary"]))
+            alarm = TeamsAlarm(name, status.lower(), severity, summary, instance, description)
+            json_alarm = schema.dump(alarm).data
+            teams_alarms.append(json_alarm)
     return teams_alarms
 
 


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions
* Remember to set **idealista:develop** as base branch;

### Description of the Change

Alarms will always be grouped by status. 
They can be grouped based on another field too, but the status grouping will be respected (resolved alarms will never be grouped together with firing ones).


### Benefits

Ease visual comprehension of the alarms.

### Possible Drawbacks


### Applicable Issues

