### PR TITLE
Fixes #105 marshmallow.exceptions.ValidationError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a ch
 ## [Unreleased](https://github.com/idealista/prom2teams/tree/develop)
 ## Changed
 - *[#102](https://github.com/idealista/prom2teams/pull/102) Requests update* @manuhortet
+### Fixed
+- *[#105](https://github.com/idealista/prom2teams/issues/105) marshmallow.exceptions.ValidationError* @gjermy
 
 ## [2.2.3](https://github.com/idealista/prom2teams/tree/2.2.3)
 [Full Changelog](https://github.com/idealista/prom2teams/compare/2.2.2...2.2.3)

--- a/prom2teams/prometheus/message_schema.py
+++ b/prom2teams/prometheus/message_schema.py
@@ -1,4 +1,4 @@
-from marshmallow import Schema, fields, post_load
+from marshmallow import Schema, fields, post_load, EXCLUDE
 import logging
 
 log = logging.getLogger('prom2teams')
@@ -7,8 +7,12 @@ class MessageSchema(Schema):
     receiver = fields.Str()
     status = fields.Str(default='unknown', missing='unknown')
     alerts = fields.Nested('AlertSchema', many=True)
+    groupKey = fields.Str()
     externalURL = fields.Str()
     version = fields.Str()
+    commonAnnotations = fields.Nested('AnnotationSchema', many=False, unknown=EXCLUDE)
+    commonLabels = fields.Nested('LabelSchema', many=False, unknown=EXCLUDE)    
+    groupLabels = fields.Nested('LabelSchema', many=False, unknown=EXCLUDE)    
 
     @post_load
     def get_alerts(self, message):
@@ -29,8 +33,8 @@ class MessageSchema(Schema):
 
 class AlertSchema(Schema):
     status = fields.Str(default='unknown', missing='unknown')
-    labels = fields.Nested('LabelSchema', many=False)
-    annotations = fields.Nested('AnnotationSchema', many=False)
+    labels = fields.Nested('LabelSchema', many=False, unknown=EXCLUDE)
+    annotations = fields.Nested('AnnotationSchema', many=False, unknown=EXCLUDE)
     startsAt = fields.Date()
     endsAt = fields.Date()
     generatorURL = fields.Str()

--- a/tests/data/jsons/teams_alarm_with_common_items.json
+++ b/tests/data/jsons/teams_alarm_with_common_items.json
@@ -1,0 +1,27 @@
+{
+    "@type": "MessageCard",
+    "@context": "http://schema.org/extensions",
+    "themeColor": " 2DC72D ",
+    "summary": "(Resolved) CPU throttling",
+    "title": "Prometheus alarm (Resolved) ",
+    "sections": [{
+        "activityTitle": "CPU throttling",
+        "facts": [{
+            "name": "Alarm",
+            "value": "CPUThrottlingHigh"
+        },{
+            "name": "In host",
+            "value": "unknown"
+        },{
+            "name": "Severity",
+            "value": "warning"
+        },{
+            "name": "Description",
+            "value": "unknown"
+        },{
+            "name": "Status",
+            "value": "resolved"
+        }],
+           "markdown": true
+    }]
+}

--- a/tests/data/jsons/with_common_items.json
+++ b/tests/data/jsons/with_common_items.json
@@ -1,0 +1,41 @@
+{
+      "receiver": "echo",
+      "status": "resolved",
+      "alerts": [
+        {
+          "status": "resolved",
+          "labels": {
+            "alertname": "CPUThrottlingHigh",
+            "container_name": "config-reloader",
+            "namespace": "monitoring",
+            "pod_name": "alertmanager-ot-mon-prometheus-operator-alertmanager-0",
+            "prometheus": "monitoring/ot-mon-prometheus-operator-prometheus",
+            "severity": "warning"
+          },
+          "annotations": {
+            "message": "27% throttling of CPU in namespace monitoring for container config-reloader in pod alertmanager-ot-mon-prometheus-operator-alertmanager-0.",
+            "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-cputhrottlinghigh",
+            "summary": "CPU throttling"
+          },
+          "startsAt": "2019-01-28T20:26:23.868893259Z",
+          "endsAt": "2019-01-28T20:27:23.868893259Z",
+          "generatorURL": "http://ot-mon-prometheus-operator-prometheus.monitoring:9090/graph?g0.expr=100+%2A+sum+by%28container_name%2C+pod_name%2C+namespace%29+%28increase%28container_cpu_cfs_throttled_periods_total%5B5m%5D%29%29+%2F+sum+by%28container_name%2C+pod_name%2C+namespace%29+%28increase%28container_cpu_cfs_periods_total%5B5m%5D%29%29+%3E+25\u0026g0.tab=1"
+        }
+      ],
+      "groupLabels": {},
+      "commonLabels": {
+        "alertname": "CPUThrottlingHigh",
+        "container_name": "config-reloader",
+        "namespace": "monitoring",
+        "pod_name": "alertmanager-ot-mon-prometheus-operator-alertmanager-0",
+        "prometheus": "monitoring/ot-mon-prometheus-operator-prometheus",
+        "severity": "warning"
+      },
+      "commonAnnotations": {
+        "message": "27% throttling of CPU in namespace monitoring for container config-reloader in pod alertmanager-ot-mon-prometheus-operator-alertmanager-0.",
+        "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-cputhrottlinghigh"
+      },
+      "externalURL": "http://ot-mon-prometheus-operator-alertmanager.monitoring:9093",
+      "version": "4",
+      "groupKey": "{}/{alertname=\"CPUThrottlingHigh\"}:{}"
+    }

--- a/tests/test_json_fields.py
+++ b/tests/test_json_fields.py
@@ -50,6 +50,19 @@ class TestJSONFields(unittest.TestCase):
 
                 self.assertDictEqual(json_rendered, json_expected)
 
+    def test_with_common_items(self):
+        self.maxDiff = None
+        with open(self.TEST_CONFIG_FILES_PATH + 'with_common_items.json') as json_data:
+            with open(self.TEST_CONFIG_FILES_PATH + 'teams_alarm_with_common_items.json') as expected_data:
+                json_received = json.load(json_data)
+                json_expected = json.load(expected_data)
+
+                alerts = MessageSchema().load(json_received)
+                rendered_data = AlarmSender()._create_alarms(alerts)[0]
+                json_rendered = json.loads(rendered_data)
+
+                self.assertDictEqual(json_rendered, json_expected)
+
     def test_grouping_multiple_alerts(self):
         with open(self.TEST_CONFIG_FILES_PATH + 'all_ok_multiple.json') as json_data:
             with open(self.TEST_CONFIG_FILES_PATH + 'teams_alarm_all_ok_multiple.json') as expected_data:


### PR DESCRIPTION
### Description of the Change

Cope with Prometheus alerts containing commonAnnotations, commonLabels, groupLabels and a groupKey at the Message level. See [with_common_items.json](tests/data/jsons/with_common_items.json)

Allow arbitrary label names in message.commonAnnotations, message.commonLabels, message.groupLabels, alert.labels, alert.annotations.

### Benefits

commonAnnotations etc - prometheus must have introduced these since the prom2teams integration was written.

Arbitrary labels: The prom2teams integration is otherwise tied to the particular label names coded into message_schema.py, which will likely not be same for other users alerting setups.

### Possible Drawbacks

User can not access their own arbitrary label values via the template, but as long as all information wanted to be displayed in present in the fields which are set in class PrometheusAlert.py, then this shouldn't matter,

### Applicable Issues

#105 marshmallow.exceptions.ValidationError
