### PR TITLE
Add ExtraAnnotations logic.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a ch
 
 ## [Unreleased](https://github.com/idealista/prom2teams/tree/develop)
 
+## [2.5.3](https://github.com/idealista/prom2teams/tree/2.5.3)
+[Full Changelog](https://github.com/idealista/prom2teams/compare/2.5.2...2.5.3)
+## Fixed
+- *[#138](https://github.com/idealista/prom2teams/issues/138) Add ExtraAnnotations field extraction* @Aaron-ML
+
 ## [2.5.2](https://github.com/idealista/prom2teams/tree/2.5.2)
 [Full Changelog](https://github.com/idealista/prom2teams/compare/2.5.1...2.5.2)
 ## Fixed

--- a/README.md
+++ b/README.md
@@ -203,6 +203,9 @@ Field: <Field to group alerts by> # alerts won't be grouped by default
 
 [Labels]
 Excluded: <Coma separated list of labels to ignore>
+
+[Annotations]
+Excluded: <Comma separated list of annotations to ignore>
 ```
 
 **Note:** Grouping alerts works since v2.2.0
@@ -227,7 +230,7 @@ prom2teams provides a [default template](prom2teams/resources/templates/teams.j2
 Some fields are considered mandatory when received from Alert Manager.
 If such a field is not included a default value of 'unknown' is assigned.
 
-All non-mandatory fields and not in excluded list are injected in `extra_labels` key.
+All non-mandatory labels not in excluded list are injected in `extra_labels` key. All non-mandatory annotations not in excluded list are injected in `extra_annotations` key.
 
 #### Swagger UI
 

--- a/helm/files/teams.j2
+++ b/helm/files/teams.j2
@@ -13,9 +13,9 @@
     "@context": "http://schema.org/extensions",
     "themeColor": "{% if status=='resolved' %} {{ theme_colors.resolved }} {% else %} {{ theme_colors[msg_text.severity] }} {% endif %}",
     "summary": "{% if status=='resolved' %}(Resolved) {% endif %}{{ msg_text.summary }}",
-    "title": "{{ msg_text.name }} {% if status=='resolved' %}(Resolved) {% elif status=='unknown' %} (status unknown) {% endif %}",
+    "title": "Prometheus alarm {% if status=='resolved' %}(Resolved) {% elif status=='unknown' %} (status unknown) {% endif %}",
     "sections": [{
-        "activityTitle": "{{ msg_text.message }}",
+        "activityTitle": "{{ msg_text.summary }}",
         "facts": [{% if msg_text.name %}{
             "name": "Alarm",
             "value": "{{ msg_text.name }}"
@@ -25,9 +25,6 @@
         },{% endif %}{% if msg_text.severity %}{
             "name": "Severity",
             "value": "{{ msg_text.severity }}"
-        },{% endif %}{% if msg_text.runbook_url %}{
-            "name": "Runbook",
-            "value": "{{ msg_text.runbook_url }}"
         },{% endif %}{% if msg_text.description %}{
             "name": "Description",
             "value": "{{ msg_text.description }}"
@@ -37,6 +34,10 @@
         }{% if msg_text.extra_labels %}{% for key in msg_text.extra_labels %},{
             "name": "{{ key }}",
             "value": "{{ msg_text.extra_labels[key] }}"
+        }{% endfor %}{% endif %}
+        {% if msg_text.extra_annotations %}{% for key in msg_text.extra_annotations %},{
+            "name": "{{ key }}",
+            "value": "{{ msg_text.extra_annotations[key] }}"
         }{% endfor %}{% endif %}],
           "markdown": true
     }]

--- a/prom2teams/app/configuration.py
+++ b/prom2teams/app/configuration.py
@@ -23,6 +23,7 @@ def _config_command_line():
     parser.add_argument('-v', '--loglevel', help='log level', required=False)
     parser.add_argument('-t', '--templatepath', help='Jinja2 template file path', required=False)
     parser.add_argument('-s', '--labelsexcluded', help='prometheus custom labels to be ignored', required=False)
+    parser.add_argument('-a', '--annotationsexcluded', help='prometheus custom annotations to be ignored', required=False)
     parser.add_argument('-m', '--enablemetrics', action='store_true', help='enable Prom2teams Prometheus metrics', required=False)
     return parser.parse_args()
 
@@ -47,6 +48,8 @@ def _update_application_configuration(application, configuration):
             application.config['PORT'] = _port
     if 'Labels' in configuration:
         application.config['LABELS_EXCLUDED'] = tuple(configuration['Labels']['Excluded'].replace(' ', '').split(','))
+    if 'Annotations' in configuration:
+        application.config['ANNOTATIONS_EXCLUDED'] = tuple(configuration['Annotations']['Excluded'].replace(' ', '').split(','))
 
 
 def _config_provided(filepath):

--- a/prom2teams/app/versions/v2/namespace.py
+++ b/prom2teams/app/versions/v2/namespace.py
@@ -15,7 +15,7 @@ class AlertReceiver(Resource):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.schema = MessageSchema(exclude_fields=app.config['LABELS_EXCLUDED'])
+        self.schema = MessageSchema(exclude_fields=app.config['LABELS_EXCLUDED'], exclude_annotations=app.config['ANNOTATIONS_EXCLUDED'])
         if app.config['TEMPLATE_PATH']:
             self.sender = AlarmSender(app.config['TEMPLATE_PATH'], app.config['GROUP_ALERTS_BY'])
         else:

--- a/prom2teams/config/settings.py
+++ b/prom2teams/config/settings.py
@@ -27,3 +27,6 @@ TEMPLATE_PATH = None
 
 # Labels
 LABELS_EXCLUDED = ()
+
+# Annotations
+ANNOTATIONS_EXCLUDED = ()

--- a/prom2teams/resources/templates/teams.j2
+++ b/prom2teams/resources/templates/teams.j2
@@ -34,6 +34,10 @@
         }{% if msg_text.extra_labels %}{% for key in msg_text.extra_labels %},{
             "name": "{{ key }}",
             "value": "{{ msg_text.extra_labels[key] }}"
+        }{% endfor %}{% endif %}
+        {% if msg_text.extra_annotations %}{% for key in msg_text.extra_annotations %},{
+            "name": "{{ key }}",
+            "value": "{{ msg_text.extra_annotations[key] }}"
         }{% endfor %}{% endif %}],
           "markdown": true
     }]

--- a/prom2teams/teams/alarm_mapper.py
+++ b/prom2teams/teams/alarm_mapper.py
@@ -15,7 +15,7 @@ def map_prom_alerts_to_teams_alarms(alerts):
     for same_status_alerts in alerts:
         for alert in alerts[same_status_alerts]:
             alarm = TeamsAlarm(alert.name, alert.status.lower(), alert.severity,
-                               alert.summary, alert.instance, alert.description, alert.extra_labels)
+                               alert.summary, alert.instance, alert.description, alert.extra_labels, alert.extra_annotations)
             json_alarm = schema.dump(alarm)
             teams_alarms.append(json_alarm)
     return teams_alarms
@@ -36,12 +36,15 @@ def map_and_group(alerts, group_alerts_by):
                                                                       teams_visualization(features["status"]),
                                                                       teams_visualization(features["summary"]))
             extra_labels = dict()
+            extra_annotations = dict()
             for element in grouped_alerts[alert]:
                 if hasattr(element, 'extra_labels'):
                     extra_labels = {**extra_labels, **element.extra_labels}
+                if hasattr(element, 'extra_annotations'):
+                    extra_annotations = {**extra_annotations, **element.extra_annotations}
 
             alarm = TeamsAlarm(name, status.lower(), severity, summary,
-                               instance, description, extra_labels)
+                               instance, description, extra_labels, extra_annotations)
             json_alarm = schema.dump(alarm)
             teams_alarms.append(json_alarm)
     return teams_alarms

--- a/prom2teams/teams/teams_alarm_schema.py
+++ b/prom2teams/teams/teams_alarm_schema.py
@@ -16,10 +16,16 @@ class TeamsAlarmSchema(Schema):
         required=False,
         data_key='extra_labels'
     )
+    extra_annotations = fields.Dict(
+        keys=fields.Str(),
+        values=fields.Str(),
+        required=False,
+        data_key='extra_annotations'
+    )
 
 
 class TeamsAlarm:
-    def __init__(self, name, status, severity, summary, instance, description, extra_labels):
+    def __init__(self, name, status, severity, summary, instance, description, extra_labels, extra_annotations):
         self.name = name
         self.status = status
         self.severity = severity
@@ -27,3 +33,4 @@ class TeamsAlarm:
         self.instance = instance
         self.description = description
         self.extra_labels = extra_labels
+        self.extra_annotations = extra_annotations

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open('README.md', encoding='utf-8') as f:
 
 
 setup(name='prom2teams',
-      version='2.5.2',
+      version='2.5.3',
       description='Project that redirects Prometheus Alert Manager '
       'notifications to Microsoft Teams',
       long_description=readme,

--- a/tests/data/jsons/all_ok_extra_annotations.json
+++ b/tests/data/jsons/all_ok_extra_annotations.json
@@ -1,0 +1,29 @@
+{
+  "receiver": "test_webhook",
+  "status": "resolved",
+  "alerts": [
+    {
+      "status": "resolved",
+      "labels": {
+        "alertname": "DiskSpace",
+        "device": "rootfs",
+        "fstype": "rootfs",
+        "instance": "cs30.evilcorp",
+        "mountpoint": "/",
+        "severity": "severe"
+      },
+      "annotations": {
+        "description": "disk usage 93% on rootfs device",
+        "summary": "Disk usage alert on CS30.evilcorp",
+        "runbook_url": "https://cs30-evilcorp-runbooks.com/rootfs-device-high-disk-usage",
+        "message": "Evil Corp has a strict SLO regarding customer-facing outages involving the rootfs device"
+      },
+      "startsAt": "2017-05-09T07:01:37.803000Z",
+      "endsAt": "2017-05-09T07:08:37.818278Z",
+      "generatorURL": "my.prometheusserver.url",
+      "fingerprint": "dd19ae3d4e06ac55"
+    }
+  ],
+  "externalURL": "my.prometheusalertmanager.url",
+  "version": "4"
+}

--- a/tests/data/jsons/teams_alarm_all_ok_extra_annotations.json
+++ b/tests/data/jsons/teams_alarm_all_ok_extra_annotations.json
@@ -1,0 +1,39 @@
+{
+  "@type": "MessageCard",
+  "@context": "http://schema.org/extensions",
+  "themeColor": " 2DC72D ",
+  "summary": "(Resolved) Disk usage alert on CS30.evilcorp",
+  "title": "Prometheus alarm (Resolved) ",
+  "sections": [
+    {
+      "activityTitle": "Disk usage alert on CS30.evilcorp",
+      "facts": [
+        {
+          "name": "Alarm",
+          "value": "DiskSpace"
+        },
+        {
+          "name": "In host",
+          "value": "cs30.evilcorp"
+        },
+        {
+          "name": "Severity",
+          "value": "severe"
+        },
+        {
+          "name": "Description",
+          "value": "disk usage 93% on rootfs device"
+        },
+        {
+          "name": "Status",
+          "value": "resolved"
+        },
+        {
+          "name": "runbook_url",
+          "value": "https://cs30-evilcorp-runbooks.com/rootfs-device-high-disk-usage"
+        }
+      ],
+      "markdown": true
+    }
+  ]
+}

--- a/tests/test_json_fields.py
+++ b/tests/test_json_fields.py
@@ -7,7 +7,6 @@ from prom2teams.app.sender import AlarmSender
 
 
 class TestJSONFields(unittest.TestCase):
-
     TEST_CONFIG_FILES_PATH = 'tests/data/jsons/'
 
     def test_json_with_all_fields(self):
@@ -87,6 +86,19 @@ class TestJSONFields(unittest.TestCase):
                 json_rendered = json.loads(rendered_data)
 
                 self.assertDictEqual(json_rendered, json_expected)
+
+    def test_with_extra_annotations(self):
+        excluded_annotations = ('message', )
+        with open(self.TEST_CONFIG_FILES_PATH + 'all_ok_extra_annotations.json') as json_data:
+            with open(self.TEST_CONFIG_FILES_PATH + 'teams_alarm_all_ok_extra_annotations.json') as expected_data:
+               json_received = json.load(json_data)
+               json_expected = json.load(expected_data)
+
+               alerts = MessageSchema(exclude_annotations=excluded_annotations).load(json_received)
+               rendered_data = AlarmSender()._create_alarms(alerts)[0]
+               json_rendered = json.loads(rendered_data)
+
+               self.assertDictEqual(json_rendered, json_expected)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Commit allows for additional annotations to be included in the Teams
post, similar to how additional labels are handled.

### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions
* Remember to set **idealista:develop** as base branch;

### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

This commit enables other annotations to be included aside from the two stock categories we've accepted thus far. It was motivated by the desire to see the 'runbook_url' of a particular alert show up in our Teams postings. The strategy for enabling these extra annotations mirrors that of how we add extra labels to a given alert.


### Benefits

<!-- What benefits will be realized by the code change? -->

Additional pertinent data about an alert will be added to a Teams posting. It is our belief that some of the annotations our alerts yield (namely 'runbook_url', as mentioned above) are helpful to include in a Teams posting. Also, there is no worry of informational overload as a result of including this change, since a developer can easily leverage the 'excluded_annotations' functionality to omit annotations from the posting as they please.

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

An annotation of the form ``x.y``, e.g. ``prometheus.io/scrape: true``, would traditionally be interpreted by the JSON parser as an object with the value of a nested object. As in, it would look like this: ``{ prometheus: {'io/scrape': true}``. These two representations are not the same and could cause confusion. For now, this commit safeguards against situations where an annotation can be parsed as an object with nested objects. This is a possible drawback because it reduces the set of items you can include in your Teams posting.

### Applicable Issues

<!-- Enter any applicable Issues here -->

https://github.com/idealista/prom2teams/issues/138

### Tests

This commit has passed all tests run with the command ``python3 -m unittest discover tests``. It also introduces a new test that tests the extra annotations functionality. It passes this test, too.

