### PR TITLE
Multiple connectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a changelog](https://github.com/olivierlacan/keep-a-changelog).
 
 ## [Unreleased](https://github.com/idealista/prom2teams/tree/develop)
+## Added
+- *[#170](https://github.com/idealista/prom2teams/issues/170) Allow specifying multiple connectors* @krmichel
 
 ## [2.5.5](https://github.com/idealista/prom2teams/tree/2.5.5)
 [Full Changelog](https://github.com/idealista/prom2teams/compare/2.5.4...2.5.5)

--- a/README.md
+++ b/README.md
@@ -107,10 +107,20 @@ After a few seconds, Prom2Teams should be running.
 
 To uninstall/delete the `my-release` deployment:
 
+##### Helm 2
+
 ```bash
 $ helm delete my-release
 ```
 > **Tip**: Use helm delete --purge my-release to completely remove the release from Helm internal storage
+
+The command removes all the Kubernetes components associated with the chart and deletes the release.
+
+##### Helm 3
+
+```bash
+$ helm uninstall my-release
+```
 
 The command removes all the Kubernetes components associated with the chart and deletes the release.
 
@@ -121,7 +131,7 @@ The following table lists the configurable parameters of the Prom2teams chart an
 | Parameter                                       | Description                                                                                                        | Default
 | ---                                             | ---                                                                                                                | ---
 | `image.repository`                              | The image repository to pull from                                                                                  | `idealista/prom2teams`
-| `image.tag`                                     | The image tag to pull                                                                                              | `2.4.0`
+| `image.tag`                                     | The image tag to pull                                                                                              | `<empty>`
 | `image.pullPolicy`                              | The image pull policy                                                                                              | `IfNotPresent`
 | `resources.requests.cpu`                        | CPU requested for being run in a node                                                                              | `100m`
 | `resources.requests.memory`                     | Memory requested for being run in a node                                                                           | `128Mi`
@@ -132,6 +142,7 @@ The following table lists the configurable parameters of the Prom2teams chart an
 | `prom2teams.host`                               | IP to bind to                                                                                                      | `0.0.0.0`
 | `prom2teams.port`                               | Port to bind to                                                                                                    | `8089`
 | `prom2teams.connector`                          | Connector URL                                                                                                      | `<empty>`
+| `prom2teams.connectors`                         | A map where the keys are the connector names and the values are the connector webhook urls                         | `{}`
 | `prom2teams.group_alerts_by`                    | Group_alerts_by field                                                                                              | `<empty>`
 | `prom2teams.loglevel`                           | Loglevel                                                                                                           | `INFO`
 | `prom2teams.templatepath`                       | Custom Template path (files/teams.j2)                                                                              | `/opt/prom2teams/helmconfig/teams.j2`

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: "1.0"
+appVersion: "2.5.2"
 description: A Helm chart for Prom2Teams
 name: prom2teams
-version: 0.1.0
+version: 0.2.0

--- a/helm/templates/configmap.yaml
+++ b/helm/templates/configmap.yaml
@@ -2,6 +2,12 @@
 {{- if not (has .Values.prom2teams.loglevel $valid) -}}
 {{- fail "Invalid log level"}}
 {{- end -}}
+{{- if and .Values.prom2teams.connector (hasKey .Values.prom2teams.connectors "Connector") -}}
+{{- fail "Invalid configuration: prom2teams.connectors can't have a connector named Connector when prom2teams.connector is set"}}
+{{- end -}}
+{{- if and (not .Values.prom2teams.connector) (not .Values.prom2teams.connectors) -}}
+{{- fail "Invalid configuration: At least one connector must be provided"}}
+{{- end -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/helm/templates/configmap.yaml
+++ b/helm/templates/configmap.yaml
@@ -1,3 +1,7 @@
+{{- $valid := list "DEBUG" "INFO" "WARNING" "ERROR" "CRITICAL" -}}
+{{- if not (has .Values.prom2teams.loglevel $valid) -}}
+{{- fail "Invalid log level"}}
+{{- end -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -8,15 +12,19 @@ metadata:
 data:
   config.ini: |-
     [HTTP Server]
-    Host: {{ .Values.prom2teams.ip }}
+    Host: {{ .Values.prom2teams.host }}
     Port: {{ .Values.prom2teams.port }}
     [Microsoft Teams]
-    Connector: {{ .Values.prom2teams.connector }}
+    {{- with .Values.prom2teams.connector }}
+    Connector: {{ . }}
+    {{- end }}
+    {{- range $key, $val := .Values.prom2teams.connectors }}
+    {{ $key }}: {{ $val }}
+    {{- end }}
     [Group Alerts]
     Field: {{ .Values.prom2teams.group_alerts_by }}
     [Log]
     Level: {{ .Values.prom2teams.loglevel }}
     [Template]
     Path: {{ .Values.prom2teams.templatepath }}
-  #config.ini: {{ .Files.Get "files/config.ini" | quote }}
   teams.j2: {{ .Files.Get "files/teams.j2" |  quote }}

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -26,7 +26,7 @@ spec:
             name: prom2teams-config
       containers:
         - name: {{ .Chart.Name }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          image: "{{ .Values.image.repository }}:{{ default .Chart.AppVersion .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: http

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -4,7 +4,7 @@
 
 image:
   repository: idealista/prom2teams
-  tag: 2.5.2
+  tag:
   pullPolicy: IfNotPresent
 
 resources:
@@ -22,7 +22,8 @@ service:
 prom2teams:
   host: 0.0.0.0
   port: 8089
-  connector: 
+  connector:
+  connectors: {}
   group_alerts_by:
   loglevel: INFO
   templatepath: /opt/prom2teams/helmconfig/teams.j2


### PR DESCRIPTION
### Description of the Change

I would like to be able to specify multiple connectors with out having to create my own ini file and configmap out side of the chart.  I have added the ability to do that with the chart by adding a map to the values that can contain multiple connector name and urls.

### Benefits

Being able to install the helm chart and specify multiple connectors without breaking backwards compatibility.  I also added validation to make sure the log level provided is a valid value.  I also changed the deployment to use the chart's appVersion as the default image tag if one isn't provided.

### Possible Drawbacks

If someone was supplying an invalid log level before and it didn't cause a crash loop they would no longer be able to use their same values and have a successful installation

### Applicable Issues

fixes #170
