### PR TITLE
#189 Fixed handling of additional json properties of alertmanager 0.21.0.

### DIFF
--- a/prom2teams/app/versions/v2/namespace.py
+++ b/prom2teams/app/versions/v2/namespace.py
@@ -15,7 +15,7 @@ class AlertReceiver(Resource):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.schema = MessageSchema(exclude_fields=app.config['LABELS_EXCLUDED'], exclude_annotations=app.config['ANNOTATIONS_EXCLUDED'])
+        self.schema = MessageSchema(exclude_fields=app.config['LABELS_EXCLUDED'], exclude_annotations=app.config['ANNOTATIONS_EXCLUDED'], unknown=EXCLUDE)
         if app.config['TEMPLATE_PATH']:
             self.sender = AlarmSender(app.config['TEMPLATE_PATH'], app.config['GROUP_ALERTS_BY'])
         else:


### PR DESCRIPTION
### Description of the Change

See Issue #189. Additional json properties in an alert request are not ignored, but raise an execption, breaking any setup with alertmangaer 0.21+.
I added a configuration to the schema to allow for and ignore additional json properties.
https://marshmallow.readthedocs.io/en/stable/quickstart.html#handling-unknown-fields


### Benefits

- No longer broken for alertmanager 0.21.0
- v2 Api now forward-compatible

### Possible Drawbacks

### Applicable Issues

 #189 