### PR TITLE
Register /metrics endpoint when using --enablemetrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a changelog](https://github.com/olivierlacan/keep-a-changelog).
 
 ## [Unreleased](https://github.com/idealista/prom2teams/tree/develop)
-
+### Fixed
+* [#201](https://github.com/idealista/prom2teams/issues/201) /metrics server not working
 
 ## [2.5.7](https://github.com/idealista/prom2teams/tree/2.5.7)
 [Full Changelog](https://github.com/idealista/prom2teams/compare/2.5.6...2.5.7)

--- a/prom2teams/app/configuration.py
+++ b/prom2teams/app/configuration.py
@@ -122,6 +122,7 @@ def config_app(application):
         if command_line_args.groupalertsby:
             application.config['GROUP_ALERTS_BY'] = command_line_args.groupalertsby
         if command_line_args.enablemetrics or os.environ.get('PROM2TEAMS_PROMETHEUS_METRICS', False):
+            os.environ["DEBUG_METRICS"] = "True"
             from prometheus_flask_exporter import PrometheusMetrics
             metrics = PrometheusMetrics(application)
 


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions
* Remember to set **idealista:develop** as base branch;

### Description of the Change

When -m or --enablemetrics flags an `DEBUG_METRICS` environment variable is set, this is to avoid a feature gate used in [prometheus_flask_exporter](https://github.com/rycus86/prometheus_flask_exporter)  to avoid registering `/metrics `endpoint when live reloading is enabled. [FYI](https://github.com/rycus86/prometheus_flask_exporter/blob/master/prometheus_flask_exporter/__init__.py#L240)
Prom2Teams enabled live reloading in  [v2.0.4](https://github.com/idealista/prom2teams/blob/master/CHANGELOG.md#240)

### Benefits

`/metrics ` endpoint will be created even with live reloading enabled.

### Possible Drawbacks
Future versions of [prometheus_flask_exporter](https://github.com/rycus86/prometheus_flask_exporter) may give additional functionality to `DEBUG_METRICS`.

### Applicable Issues

[#201](https://github.com/idealista/prom2teams/issues/201) /metrics server not working
