### PR TITLE
Add timeouts to webhook requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a changelog](https://github.com/olivierlacan/keep-a-changelog).
 
 ## [Unreleased](https://github.com/idealista/prom2teams/tree/develop)
-
+### Fixed
+- *[#219](https://github.com/idealista/prom2teams/pull/219) Add timeouts to webhook request to prevent hanging tcp connections in case of network errors* @DanSipola
 
 ## [3.0.0](https://github.com/idealista/prom2teams/tree/3.0.0)
 [Full Changelog](https://github.com/idealista/prom2teams/compare/2.7.0...3.0.0)

--- a/prom2teams/app/teams_client.py
+++ b/prom2teams/app/teams_client.py
@@ -7,7 +7,7 @@ session.headers.update({'Content-Type': 'application/json'})
 
 
 def post(teams_webhook_url, message):
-    response = session.post(teams_webhook_url, data=message)
+    response = session.post(teams_webhook_url, data=message, timeout=(5,20))
     if not response.ok or response.text is not '1':
         exception_msg = 'Error performing request to: {}.\n' \
                         ' Returned status code: {}.\n' \


### PR DESCRIPTION
Add timeouts to webhook requests.

### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions
* Remember to set **idealista:develop** as base branch;

### Description of the Change

I found the application in a state where it was logging messages like "uWSGI listen queue of socket full". There was a lot of connections to a uwsgi worker in close wait so I assume that over time network errors had accumulated connections to the point where the application would no longer serve requests from alertmanager.  

### Benefits

### Possible Drawbacks

Might want the timeouts configurable, however I set them generous for the purpose of avoiding bad state.

### Applicable Issues

