### PR TITLE
Enable status probes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a changelog](https://github.com/olivierlacan/keep-a-changelog).
 
 ## [Unreleased](https://github.com/idealista/prom2teams/tree/develop)
-
+### Added
+- *Add /alive and /ready endpoints* @vicsufer
 
 ## [3.0.0](https://github.com/idealista/prom2teams/tree/3.0.0)
 [Full Changelog](https://github.com/idealista/prom2teams/compare/2.7.0...3.0.0)
@@ -15,7 +16,7 @@ Now connector field is mandatory in helm chart is mantatory.
 - *[#170](https://github.com/idealista/prom2teams/issues/170) Allow specifying multiple connectors* @krmichel
 
 ## [2.7.0](https://github.com/idealista/prom2teams/tree/2.7.0)
-[Full Changelog](https://github.com/idealista/prom2teams/compare/2.6.0...2.7.0)
+[Full Changelog](https://github.com- *[#175](https://github.com/idealista/prom2teams/issues/175) Building docker image using multi-stage build feature* @dortegau/idealista/prom2teams/compare/2.6.0...2.7.0)
 ### Added
 * *[#213](https://github.com/idealista/prom2teams/issues/213) Add end to end tests* @pablogcaldito
 
@@ -30,9 +31,7 @@ Now connector field is mandatory in helm chart is mantatory.
 * *[#201](https://github.com/idealista/prom2teams/issues/201) /metrics server not working* @vicsufer
 
 
-## [2.5.7](https://github.com/idealista/prom2teams/tree/2.5.7)
-[Full Changelog](https://github.com/idealista/prom2teams/compare/2.5.6...2.5.7)
-## Fixed
+## [2.5.7](https://github.com/id- *[#175](https://github.com/idealista/prom2teams/issues/175) Building docker image using multi-stage build feature* @dortegau
 - *[#189](https://github.com/idealista/prom2teams/issues/189) Fixed handling alerts with truncated fields* @dgalcantara
 - *[#190](https://github.com/idealista/prom2teams/pull/190) Fixed handling of additional json properties of alertmanager 0.21.0* @lazyBisa
 - *[#202](https://github.com/idealista/prom2teams/issues/202) Fix error publishing 2.5.7 release* @pablogcaldito

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a ch
 
 ## [Unreleased](https://github.com/idealista/prom2teams/tree/develop)
 ### Added
-- *Add /alive and /ready endpoints* @vicsufer
+- *[#225] Add /alive and /ready endpoints* @vicsufer
 - *[#222](https://github.com/idealista/prom2teams/pull/222) Add restrictive security context since the workload doesn't need more permissions to work.* @azman0101
 
 

--- a/prom2teams/app/api.py
+++ b/prom2teams/app/api.py
@@ -13,12 +13,18 @@ log = logging.getLogger('prom2teams_app')
 
 app = Flask(__name__)
 
-
-
 @app.route('/favicon.ico')
 def favicon():
     return send_from_directory(os.path.join(app.root_path, 'static'),
                                'favicon.ico', mimetype='image/vnd.microsoft.icon')
+
+@app.route('/alive')
+def alive():
+    return "YES", 200
+
+@app.route('/ready')
+def ready():
+    return ("YES", 200) if app.config['FINISH_INIT'] else ("NO", 503)
 
 def error_handler(e):
     msg = 'An unhandled exception occurred. {}'.format(e)
@@ -43,6 +49,8 @@ def init_app(application):
     register_api(application, api_v2, ns_v2, blueprint_v2)
     application.register_error_handler(500, error_handler)
 
-
 init_app(app)
+import time
+time.sleep(10)
+app.config['FINISH_INIT'] = True
 log.info('{} started on {}:{}'.format(app.config['APP_NAME'], app.config['HOST'], app.config['PORT']))

--- a/prom2teams/app/api.py
+++ b/prom2teams/app/api.py
@@ -48,9 +48,7 @@ def init_app(application):
     register_api(application, api_v1, ns_v1, blueprint_v1)
     register_api(application, api_v2, ns_v2, blueprint_v2)
     application.register_error_handler(500, error_handler)
+    application.config['FINISH_INIT'] = True
 
 init_app(app)
-import time
-time.sleep(10)
-app.config['FINISH_INIT'] = True
 log.info('{} started on {}:{}'.format(app.config['APP_NAME'], app.config['HOST'], app.config['PORT']))


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions
* Remember to set **idealista:develop** as base branch;

### Description of the Change
Enable /alive and /ready endpoints for readiness and liveness probes.


### Benefits

Add probes

### Possible Drawbacks
N/A

### Applicable Issues
N/A