### PR TITLE
#155 using `alert` instead of `alarm`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,10 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a ch
 
 ## [Unreleased](https://github.com/idealista/prom2teams/tree/develop)
 ### Added
-- *[#225] Add /alive and /ready endpoints* @vicsufer
+- *[#225](https://github.com/idealista/prom2teams/pull/225) Add /alive and /ready endpoints* @vicsufer
+
+## Changed
+- *[#155](https://github.com/idealista/prom2teams/issues/155) Using Alert instead of Alarm in the entire code base* @dortegau
 
 ## [3.1.0](https://github.com/idealista/prom2teams/tree/3.1.0)
 [Full Changelog](https://github.com/idealista/prom2teams/compare/3.0.0...3.1.0)
@@ -13,8 +16,6 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a ch
 ### Added
 - *[#222](https://github.com/idealista/prom2teams/pull/222) Add restrictive security context since the workload doesn't need more permissions to work.* @azman0101
 - *[#226](https://github.com/idealista/prom2teams/pull/226) Retrying policy* @blalop
-
-
 
 ## [3.0.0](https://github.com/idealista/prom2teams/tree/3.0.0)
 [Full Changelog](https://github.com/idealista/prom2teams/compare/2.7.0...3.0.0)
@@ -145,7 +146,7 @@ Now connector field is mandatory in helm chart is mantatory.
 ## [2.2.1](https://github.com/idealista/prom2teams/tree/2.2.1)
 [Full Changelog](https://github.com/idealista/prom2teams/compare/2.1.2...2.2.1)
 ## Added
-- *[#80](https://github.com/idealista/prom2teams/pull/79) Add the possibility of group alarms by alertname* @manuhortet
+- *[#80](https://github.com/idealista/prom2teams/pull/79) Add the possibility of group alerts by alertname* @manuhortet
 - *[#84](https://github.com/idealista/prom2teams/issues/84) View received message when debugging* @jnogol
 - *Update Flask version to v1.0.2* @manuhortet @jnogol
 
@@ -201,7 +202,7 @@ Now connector field is mandatory in helm chart is mantatory.
 - *[#32](https://github.com/idealista/prom2teams/issues/32) Set default value for "instance" in alerts* @maglo
 
 ### Fixed
-- *[#26](https://github.com/idealista/prom2teams/issues/26) Able to handle multiple received alarms* @jnogol
+- *[#26](https://github.com/idealista/prom2teams/issues/26) Able to handle multiple received alerts* @jnogol
 
 ## [1.1.3](https://github.com/idealista/prom2teams/tree/1.1.3)
 [Full Changelog](https://github.com/idealista/prom2teams/compare/1.1.2...1.1.3)

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 **prom2teams** is a Web server built with Python that receives alert notifications from a previously configured [Prometheus Alertmanager](https://github.com/prometheus/alertmanager) instance and forwards it to [Microsoft Teams](https://teams.microsoft.com/) using defined connectors.
 
-It presents grouping of alerts, labels/annotations exclusion and a Teams' alarm retry policy among its key features.
+It presents grouping of alerts, labels/annotations exclusion and a Teams' alert retry policy among its key features.
 
 
 - [Getting Started](#getting-started)

--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ Path: <Jinja2 template path> # default: app resources template
 Field: <Field to group alerts by> # alerts won't be grouped by default
 
 [Labels]
-Excluded: <Coma separated list of labels to ignore>
+Excluded: <Comma separated list of labels to ignore>
 
 [Annotations]
 Excluded: <Comma separated list of annotations to ignore>

--- a/helm/files/teams.j2
+++ b/helm/files/teams.j2
@@ -13,11 +13,11 @@
     "@context": "http://schema.org/extensions",
     "themeColor": "{% if status=='resolved' %} {{ theme_colors.resolved }} {% else %} {{ theme_colors[msg_text.severity] }} {% endif %}",
     "summary": "{% if status=='resolved' %}(Resolved) {% endif %}{{ msg_text.summary }}",
-    "title": "Prometheus alarm {% if status=='resolved' %}(Resolved) {% elif status=='unknown' %} (status unknown) {% endif %}",
+    "title": "Prometheus alert {% if status=='resolved' %}(Resolved) {% elif status=='unknown' %} (status unknown) {% endif %}",
     "sections": [{
         "activityTitle": "{{ msg_text.summary }}",
         "facts": [{% if msg_text.name %}{
-            "name": "Alarm",
+            "name": "Alert",
             "value": "{{ msg_text.name }}"
         },{% endif %}{% if msg_text.instance %}{
             "name": "In host",

--- a/prom2teams/app/configuration.py
+++ b/prom2teams/app/configuration.py
@@ -18,7 +18,7 @@ def _config_command_line():
                                                  'and sends it to Microsoft Teams using configured connectors ')
 
     parser.add_argument('-c', '--configpath', help='config INI file path', required=False)
-    parser.add_argument('-g', '--groupalertsby', help='group alerts with same attribute into one alarm', required=False)
+    parser.add_argument('-g', '--groupalertsby', help='group alerts with same attribute into one alert', required=False)
     parser.add_argument('-l', '--logfilepath', help='log file path', required=False)
     parser.add_argument('-v', '--loglevel', help='log level', required=False)
     parser.add_argument('-t', '--templatepath', help='Jinja2 template file path', required=False)

--- a/prom2teams/app/sender.py
+++ b/prom2teams/app/sender.py
@@ -1,26 +1,26 @@
 
 
-from prom2teams.teams.alarm_mapper import map_and_group, map_prom_alerts_to_teams_alarms
+from prom2teams.teams.alert_mapper import map_and_group, map_prom_alerts_to_teams_alerts
 from prom2teams.teams.composer import TemplateComposer
 from .teams_client import TeamsClient
 
 
 
-class AlarmSender:
+class AlertSender:
     def __init__(self, template_path=None, group_alerts_by=False, teams_client_config=None):
         self.json_composer = TemplateComposer(template_path)
         self.group_alerts_by = group_alerts_by
         self.teams_client = TeamsClient(teams_client_config)
         self.max_payload = self.teams_client.max_payload_length
 
-    def _create_alarms(self, alerts):
+    def _create_alerts(self, alerts):
         if self.group_alerts_by:
-            alarms = map_and_group(alerts, self.group_alerts_by, self.json_composer.compose, self.max_payload)
+            alerts = map_and_group(alerts, self.group_alerts_by, self.json_composer.compose, self.max_payload)
         else:
-            alarms = map_prom_alerts_to_teams_alarms(alerts)
-        return self.json_composer.compose_all(alarms)
+            alerts = map_prom_alerts_to_teams_alerts(alerts)
+        return self.json_composer.compose_all(alerts)
 
-    def send_alarms(self, alerts, teams_webhook_url):
-        sending_alarms = self._create_alarms(alerts)
-        for team_alarm in sending_alarms:
-            self.teams_client.post(teams_webhook_url, team_alarm)
+    def send_alerts(self, alerts, teams_webhook_url):
+        sending_alerts = self._create_alerts(alerts)
+        for team_alert in sending_alerts:
+            self.teams_client.post(teams_webhook_url, team_alert)

--- a/prom2teams/app/versions/v1/namespace.py
+++ b/prom2teams/app/versions/v1/namespace.py
@@ -3,7 +3,7 @@ import warnings
 from flask import request, current_app as app
 from flask_restplus import Resource
 
-from prom2teams.app.sender import AlarmSender
+from prom2teams.app.sender import AlertSender
 from prom2teams.prometheus.message_schema import MessageSchema
 from .model import *
 
@@ -17,7 +17,7 @@ class AlertReceiver(Resource):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.schema = MessageSchema()
-        self.sender = AlarmSender(template_path=app.config.get('TEMPLATE_PATH'),
+        self.sender = AlertSender(template_path=app.config.get('TEMPLATE_PATH'),
                                   teams_client_config=app.config.get('TEAMS_CLIENT_CONFIG'))
 
     @api_v1.expect(message)
@@ -25,7 +25,7 @@ class AlertReceiver(Resource):
         _show_deprecated_warning("Call to deprecated function. It will be removed in future versions. "
                                  "Please view the README file.")
         alerts = self.schema.load(request.get_json())
-        self.sender.send_alarms(alerts, app.config['MICROSOFT_TEAMS']['Connector'])
+        self.sender.send_alerts(alerts, app.config['MICROSOFT_TEAMS']['Connector'])
         return 'OK', 201
 
 

--- a/prom2teams/app/versions/v2/namespace.py
+++ b/prom2teams/app/versions/v2/namespace.py
@@ -1,7 +1,7 @@
 from flask import request, current_app as app
 from flask_restplus import Resource
 
-from prom2teams.app.sender import AlarmSender
+from prom2teams.app.sender import AlertSender
 from prom2teams.prometheus.message_schema import MessageSchema
 from .model import *
 from marshmallow import EXCLUDE
@@ -17,12 +17,12 @@ class AlertReceiver(Resource):
         super().__init__(*args, **kwargs)
         self.schema = MessageSchema(exclude_fields=app.config['LABELS_EXCLUDED'],
                                     exclude_annotations=app.config['ANNOTATIONS_EXCLUDED'])
-        self.sender = AlarmSender(template_path=app.config.get('TEMPLATE_PATH'),
+        self.sender = AlertSender(template_path=app.config.get('TEMPLATE_PATH'),
                                   group_alerts_by=app.config['GROUP_ALERTS_BY'],
                                   teams_client_config=app.config.get('TEAMS_CLIENT_CONFIG'))
 
     @api_v2.expect(message)
     def post(self, connector):
         alerts = self.schema.load(request.get_json())
-        self.sender.send_alarms(alerts, app.config['MICROSOFT_TEAMS'][connector])
+        self.sender.send_alerts(alerts, app.config['MICROSOFT_TEAMS'][connector])
         return 'OK', 201

--- a/prom2teams/resources/templates/teams.j2
+++ b/prom2teams/resources/templates/teams.j2
@@ -13,11 +13,11 @@
     "@context": "http://schema.org/extensions",
     "themeColor": "{% if status=='resolved' %} {{ theme_colors.resolved }} {% else %} {{ theme_colors[msg_text.severity] }} {% endif %}",
     "summary": "{% if status=='resolved' %}(Resolved) {% endif %}{{ msg_text.summary }}",
-    "title": "Prometheus alarm {% if status=='resolved' %}(Resolved) {% elif status=='unknown' %} (status unknown) {% endif %}",
+    "title": "Prometheus alert {% if status=='resolved' %}(Resolved) {% elif status=='unknown' %} (status unknown) {% endif %}",
     "sections": [{
         "activityTitle": "{{ msg_text.summary }}",
         "facts": [{% if msg_text.name %}{
-            "name": "Alarm",
+            "name": "Alert",
             "value": "{{ msg_text.name }}"
         },{% endif %}{% if msg_text.instance %}{
             "name": "In host",

--- a/prom2teams/teams/alert_mapper.py
+++ b/prom2teams/teams/alert_mapper.py
@@ -1,6 +1,6 @@
 from collections import defaultdict, OrderedDict
 
-from prom2teams.teams.teams_alarm_schema import TeamsAlarm, TeamsAlarmSchema
+from prom2teams.teams.teams_alert_schema import TeamsAlert, TeamsAlertSchema
 
 GROUPABLE_FIELDS = ['name', 'description', 'instance',
                     'severity', 'status', 'summary', 'fingerprint']
@@ -8,60 +8,60 @@ EXTRA_FIELDS = ['extra_labels', 'extra_annotations']
 FIELD_SEPARATOR = ',\n\n\n'
 
 
-def map_prom_alerts_to_teams_alarms(alerts):
+def map_prom_alerts_to_teams_alerts(alerts):
     alerts = _group_alerts(alerts, 'status')
-    teams_alarms = []
-    schema = TeamsAlarmSchema()
+    teams_alerts = []
+    schema = TeamsAlertSchema()
     for same_status_alerts in alerts:
         for alert in alerts[same_status_alerts]:
-            alarm = TeamsAlarm(alert.name, alert.status.lower(), alert.severity,
+            alert = TeamsAlert(alert.name, alert.status.lower(), alert.severity,
                                alert.summary, alert.instance, alert.description,
                                alert.fingerprint, alert.extra_labels,
                                alert.extra_annotations)
-            json_alarm = schema.dump(alarm)
-            teams_alarms.append(json_alarm)
-    return teams_alarms
+            json_alert = schema.dump(alert)
+            teams_alerts.append(json_alert)
+    return teams_alerts
 
 
 def map_and_group(alerts, group_alerts_by, compose, payload_limit):
     alerts = _group_alerts(alerts, 'status')
-    teams_alarms = []
+    teams_alerts = []
     for same_status_alerts in alerts:
         grouped_alerts = _group_alerts(alerts[same_status_alerts], group_alerts_by)
         for alert_group in grouped_alerts.values():
-            json_alarms = _map_group(alert_group, compose, payload_limit)
-            teams_alarms.extend(json_alarms)
-    return teams_alarms
+            json_alerts = _map_group(alert_group, compose, payload_limit)
+            teams_alerts.extend(json_alerts)
+    return teams_alerts
 
 
 def _map_group(alert_group, compose, payload_limit):
-    schema = TeamsAlarmSchema()
+    schema = TeamsAlertSchema()
     combined_alerts = []
-    teams_alarms = []
+    teams_alerts = []
     for alert in alert_group:
-        json_alarm = schema.dump(_combine_alerts_to_alarm([*combined_alerts, alert]))
-        if len(compose(json_alarm).encode('utf-8')) > payload_limit:
-            teams_alarms.append(schema.dump(_combine_alerts_to_alarm([alert])))
-            teams_alarms.append(schema.dump(_combine_alerts_to_alarm(combined_alerts)))
+        json_alert = schema.dump(_combine_alerts_to_alert([*combined_alerts, alert]))
+        if len(compose(json_alert).encode('utf-8')) > payload_limit:
+            teams_alerts.append(schema.dump(_combine_alerts_to_alert([alert])))
+            teams_alerts.append(schema.dump(_combine_alerts_to_alert(combined_alerts)))
             combined_alerts.clear()
-            json_alarm = None
+            json_alert = None
         else:
             combined_alerts.append(alert)
 
-    if json_alarm:
-        teams_alarms.append(json_alarm)
-    return teams_alarms
+    if json_alert:
+        teams_alerts.append(json_alert)
+    return teams_alerts
 
 
-def _combine_alerts_to_alarm(alerts):
+def _combine_alerts_to_alert(alerts):
     dicts = list(map(vars, alerts))
     groupable = _combine_groupable_fields(dicts)
     extra = _combine_extra_fields(dicts)
-    return _map_dict_alert_to_alarm({**groupable, **extra})
+    return _map_dict_alert_to_alert({**groupable, **extra})
 
 
-def _map_dict_alert_to_alarm(alert):
-    return TeamsAlarm(alert['name'], alert['status'].lower(), alert['severity'], alert['summary'],
+def _map_dict_alert_to_alert(alert):
+    return TeamsAlert(alert['name'], alert['status'].lower(), alert['severity'], alert['summary'],
                       alert['instance'], alert['description'], alert['fingerprint'],
                       alert['extra_labels'], alert['extra_annotations'])
 

--- a/prom2teams/teams/teams_alert_schema.py
+++ b/prom2teams/teams/teams_alert_schema.py
@@ -1,7 +1,7 @@
 from marshmallow import Schema, fields, INCLUDE
 
 
-class TeamsAlarmSchema(Schema):
+class TeamsAlertSchema(Schema):
     class Meta:
         unknown = INCLUDE
     status = fields.Str()
@@ -25,7 +25,7 @@ class TeamsAlarmSchema(Schema):
     )
 
 
-class TeamsAlarm:
+class TeamsAlert:
     def __init__(self, name, status, severity, summary, instance, description, fingerprint, extra_labels, extra_annotations):
         self.name = name
         self.status = status

--- a/tests/data/json_files/teams_alert_all_ok.json
+++ b/tests/data/json_files/teams_alert_all_ok.json
@@ -3,11 +3,11 @@
     "@context": "http://schema.org/extensions",
     "themeColor": " 2DC72D ",
     "summary": "(Resolved) Disk usage alert on CS30.evilcorp",
-    "title": "Prometheus alarm (Resolved) ",
+    "title": "Prometheus alert (Resolved) ",
     "sections": [{
         "activityTitle": "Disk usage alert on CS30.evilcorp",
         "facts": [{
-            "name": "Alarm",
+            "name": "Alert",
             "value": "DiskSpace"
         },{
             "name": "In host",

--- a/tests/data/json_files/teams_alert_all_ok_extra_annotations.json
+++ b/tests/data/json_files/teams_alert_all_ok_extra_annotations.json
@@ -3,13 +3,13 @@
   "@context": "http://schema.org/extensions",
   "themeColor": " 2DC72D ",
   "summary": "(Resolved) Disk usage alert on CS30.evilcorp",
-  "title": "Prometheus alarm (Resolved) ",
+  "title": "Prometheus alert (Resolved) ",
   "sections": [
     {
       "activityTitle": "Disk usage alert on CS30.evilcorp",
       "facts": [
         {
-          "name": "Alarm",
+          "name": "Alert",
           "value": "DiskSpace"
         },
         {

--- a/tests/data/json_files/teams_alert_all_ok_extra_labels.json
+++ b/tests/data/json_files/teams_alert_all_ok_extra_labels.json
@@ -3,13 +3,13 @@
     "@context": "http://schema.org/extensions",
     "themeColor": " 2DC72D ",
     "summary": "(Resolved) Disk usage alert on CS30.evilcorp",
-    "title": "Prometheus alarm (Resolved) ",
+    "title": "Prometheus alert (Resolved) ",
     "sections": [
         {
             "activityTitle": "Disk usage alert on CS30.evilcorp",
             "facts": [
                 {
-                    "name": "Alarm",
+                    "name": "Alert",
                     "value": "DiskSpace"
                 },
                 {

--- a/tests/data/json_files/teams_alert_all_ok_multiple.json
+++ b/tests/data/json_files/teams_alert_all_ok_multiple.json
@@ -3,11 +3,11 @@
     "@context": "http://schema.org/extensions",
     "themeColor": " 2DC72D ",
     "summary": "(Resolved) Disk usage alert on CS30.evilcorp, Disk usage alert on CS31.evilcorp",
-    "title": "Prometheus alarm (Resolved) ",
+    "title": "Prometheus alert (Resolved) ",
     "sections": [{
         "activityTitle": "Disk usage alert on CS30.evilcorp, Disk usage alert on CS31.evilcorp",
         "facts": [{
-            "name": "Alarm",
+            "name": "Alert",
             "value": "DiskSpace"
         },{
             "name": "In host",

--- a/tests/data/json_files/teams_alert_all_ok_splitted.json
+++ b/tests/data/json_files/teams_alert_all_ok_splitted.json
@@ -4,13 +4,13 @@
             "@context": "http://schema.org/extensions",
             "themeColor": " 2DC72D ",
             "summary": "(Resolved) Disk usage alert on CS31.evilcorp",
-            "title": "Prometheus alarm (Resolved) ",
+            "title": "Prometheus alert (Resolved) ",
             "sections": [
                 {
                     "activityTitle": "Disk usage alert on CS31.evilcorp",
                     "facts": [
                         {
-                            "name": "Alarm",
+                            "name": "Alert",
                             "value": "DiskSpace"
                         },
                         {
@@ -39,13 +39,13 @@
             "@context": "http://schema.org/extensions",
             "themeColor": " 2DC72D ",
             "summary": "(Resolved) Disk usage alert on CS30.evilcorp",
-            "title": "Prometheus alarm (Resolved) ",
+            "title": "Prometheus alert (Resolved) ",
             "sections": [
                 {
                     "activityTitle": "Disk usage alert on CS30.evilcorp",
                     "facts": [
                         {
-                            "name": "Alarm",
+                            "name": "Alert",
                             "value": "DiskSpace"
                         },
                         {

--- a/tests/data/json_files/teams_alert_with_common_items.json
+++ b/tests/data/json_files/teams_alert_with_common_items.json
@@ -3,13 +3,13 @@
     "@context": "http://schema.org/extensions",
     "themeColor": " 2DC72D ",
     "summary": "(Resolved) CPU throttling",
-    "title": "Prometheus alarm (Resolved) ",
+    "title": "Prometheus alert (Resolved) ",
     "sections": [
         {
             "activityTitle": "CPU throttling",
             "facts": [
                 {
-                    "name": "Alarm",
+                    "name": "Alert",
                     "value": "CPUThrottlingHigh"
                 },
                 {

--- a/tests/e2e/test.sh
+++ b/tests/e2e/test.sh
@@ -18,11 +18,11 @@ create_expectations_and_responses(){
         "@context": "http://schema.org/extensions",
         "themeColor": " 8C1A1A ",
         "summary": "Node exporter down on node1.summit",
-        "title": "Prometheus alarm ",
+        "title": "Prometheus alert ",
         "sections": [{
             "activityTitle": "Node exporter down on node1.summit",
             "facts": [{
-                "name": "Alarm",
+                "name": "Alert",
                 "value": "NodeExporter"
             },{
                 "name": "In host",
@@ -69,11 +69,11 @@ create_expectations_and_responses(){
         "@context": "http://schema.org/extensions",
         "themeColor": " 8C1A1A ",
         "summary": "Node exporter down on node2.summit",
-        "title": "Prometheus alarm ",
+        "title": "Prometheus alert ",
         "sections": [{
             "activityTitle": "Node exporter down on node2.summit",
             "facts": [{
-                "name": "Alarm",
+                "name": "Alert",
                 "value": "NodeExporter"
             },{
                 "name": "In host",
@@ -127,11 +127,11 @@ run_tests(){
         "@context": "http://schema.org/extensions",
         "themeColor": " 8C1A1A ",
         "summary": "Node exporter down on node1.summit",
-        "title": "Prometheus alarm ",
+        "title": "Prometheus alert ",
         "sections": [{
             "activityTitle": "Node exporter down on node1.summit",
             "facts": [{
-                "name": "Alarm",
+                "name": "Alert",
                 "value": "NodeExporter"
             },{
                 "name": "In host",
@@ -177,11 +177,11 @@ run_tests(){
         "@context": "http://schema.org/extensions",
         "themeColor": " 8C1A1A ",
         "summary": "Node exporter down on node2.summit",
-        "title": "Prometheus alarm ",
+        "title": "Prometheus alert ",
         "sections": [{
             "activityTitle": "Node exporter down on node2.summit",
             "facts": [{
-                "name": "Alarm",
+                "name": "Alert",
                 "value": "NodeExporter"
             },{
                 "name": "In host",

--- a/tests/test_json_fields.py
+++ b/tests/test_json_fields.py
@@ -2,9 +2,9 @@ import unittest
 import os
 import json
 
-from prom2teams.teams.alarm_mapper import map_prom_alerts_to_teams_alarms
+from prom2teams.teams.alert_mapper import map_prom_alerts_to_teams_alerts
 from prom2teams.prometheus.message_schema import MessageSchema
-from prom2teams.app.sender import AlarmSender
+from prom2teams.app.sender import AlertSender
 
 from deepdiff import DeepDiff
 
@@ -15,45 +15,45 @@ class TestJSONFields(unittest.TestCase):
         with open(os.path.join(self.TEST_CONFIG_FILES_PATH, 'all_ok.json')) as json_data:
             json_received = json.load(json_data)
             alerts = MessageSchema().load(json_received)
-            alarm = map_prom_alerts_to_teams_alarms(alerts)[0]
-            self.assertNotIn('unknown', str(alarm))
+            alert = map_prom_alerts_to_teams_alerts(alerts)[0]
+            self.assertNotIn('unknown', str(alert))
 
     def test_json_without_mandatory_field(self):
         with open(os.path.join(self.TEST_CONFIG_FILES_PATH, 'without_mandatory_field.json')) as json_data:
             json_received = json.load(json_data)
             alerts = MessageSchema().load(json_received)
-            alarm = map_prom_alerts_to_teams_alarms(alerts)[0]
-            self.assertIn('unknown', str(alarm))
+            alert = map_prom_alerts_to_teams_alerts(alerts)[0]
+            self.assertIn('unknown', str(alert))
 
     def test_json_without_optional_field(self):
         with open(os.path.join(self.TEST_CONFIG_FILES_PATH, 'without_optional_field.json')) as json_data:
             json_received = json.load(json_data)
             alerts = MessageSchema().load(json_received)
-            alarm = map_prom_alerts_to_teams_alarms(alerts)[0]
-            self.assertIn("'description': 'unknown'", str(alarm))
+            alert = map_prom_alerts_to_teams_alerts(alerts)[0]
+            self.assertIn("'description': 'unknown'", str(alert))
 
     def test_json_without_instance_field(self):
         with open(os.path.join(self.TEST_CONFIG_FILES_PATH, 'without_instance_field.json')) as json_data:
             json_received = json.load(json_data)
             alerts = MessageSchema().load(json_received)
-            alarm = map_prom_alerts_to_teams_alarms(alerts)[0]
-            self.assertEqual('unknown', str(alarm['instance']))
+            alert = map_prom_alerts_to_teams_alerts(alerts)[0]
+            self.assertEqual('unknown', str(alert['instance']))
 
     def test_fingerprint(self):
         with open(self.TEST_CONFIG_FILES_PATH + 'all_ok.json') as json_data:
             json_received = json.load(json_data)
             alerts = MessageSchema().load(json_received)
-            alarm = map_prom_alerts_to_teams_alarms(alerts)[0]
-            self.assertEqual('dd19ae3d4e06ac55', str(alarm['fingerprint']))
+            alert = map_prom_alerts_to_teams_alerts(alerts)[0]
+            self.assertEqual('dd19ae3d4e06ac55', str(alert['fingerprint']))
 
     def test_compose_all(self):
         with open(os.path.join(self.TEST_CONFIG_FILES_PATH, 'all_ok.json')) as json_data:
-            with open(os.path.join(self.TEST_CONFIG_FILES_PATH, 'teams_alarm_all_ok.json')) as expected_data:
+            with open(os.path.join(self.TEST_CONFIG_FILES_PATH, 'teams_alert_all_ok.json')) as expected_data:
                 json_received = json.load(json_data)
                 json_expected = json.load(expected_data)
 
                 alerts = MessageSchema().load(json_received)
-                rendered_data = AlarmSender()._create_alarms(alerts)[0]
+                rendered_data = AlertSender()._create_alerts(alerts)[0]
                 json_rendered = json.loads(rendered_data)
 
                 diff = DeepDiff(json_rendered, json_expected, ignore_order=True)
@@ -62,24 +62,24 @@ class TestJSONFields(unittest.TestCase):
     def test_with_common_items(self):
         self.maxDiff = None
         with open(os.path.join(self.TEST_CONFIG_FILES_PATH, 'with_common_items.json')) as json_data:
-            with open(os.path.join(self.TEST_CONFIG_FILES_PATH, 'teams_alarm_with_common_items.json')) as expected_data:
+            with open(os.path.join(self.TEST_CONFIG_FILES_PATH, 'teams_alert_with_common_items.json')) as expected_data:
                 json_received = json.load(json_data)
                 json_expected = json.load(expected_data)
 
                 alerts = MessageSchema().load(json_received)
-                rendered_data = AlarmSender()._create_alarms(alerts)[0]
+                rendered_data = AlertSender()._create_alerts(alerts)[0]
                 json_rendered = json.loads(rendered_data)
 
                 self.assertEqual(json_rendered.keys(), json_expected.keys())
 
     def test_grouping_multiple_alerts(self):
         with open(os.path.join(self.TEST_CONFIG_FILES_PATH, 'all_ok_multiple.json')) as json_data:
-            with open(os.path.join(self.TEST_CONFIG_FILES_PATH, 'teams_alarm_all_ok_multiple.json')) as expected_data:
+            with open(os.path.join(self.TEST_CONFIG_FILES_PATH, 'teams_alert_all_ok_multiple.json')) as expected_data:
                 json_received = json.load(json_data)
                 json_expected = json.load(expected_data)
 
                 alerts = MessageSchema().load(json_received)
-                rendered_data = AlarmSender(group_alerts_by='name')._create_alarms(alerts)[0].replace("\n\n\n", " ")
+                rendered_data = AlertSender(group_alerts_by='name')._create_alerts(alerts)[0].replace("\n\n\n", " ")
                 json_rendered = json.loads(rendered_data)
 
                 diff = DeepDiff(json_rendered, json_expected, ignore_order=True)
@@ -88,12 +88,12 @@ class TestJSONFields(unittest.TestCase):
     def test_with_extra_labels(self):
         excluded_labels = ('pod_name', )
         with open(os.path.join(self.TEST_CONFIG_FILES_PATH, 'all_ok_extra_labels.json')) as json_data:
-            with open(os.path.join(self.TEST_CONFIG_FILES_PATH, 'teams_alarm_all_ok_extra_labels.json')) as expected_data:
+            with open(os.path.join(self.TEST_CONFIG_FILES_PATH, 'teams_alert_all_ok_extra_labels.json')) as expected_data:
                 json_received = json.load(json_data)
                 json_expected = json.load(expected_data)
 
                 alerts = MessageSchema(exclude_fields=excluded_labels).load(json_received)
-                rendered_data = AlarmSender()._create_alarms(alerts)[0]
+                rendered_data = AlertSender()._create_alerts(alerts)[0]
                 json_rendered = json.loads(rendered_data)
 
                 diff = DeepDiff(json_rendered, json_expected, ignore_order=True)
@@ -102,12 +102,12 @@ class TestJSONFields(unittest.TestCase):
     def test_with_extra_annotations(self):
         excluded_annotations = ('message', )
         with open(os.path.join(self.TEST_CONFIG_FILES_PATH, 'all_ok_extra_annotations.json')) as json_data:
-            with open(os.path.join(self.TEST_CONFIG_FILES_PATH, 'teams_alarm_all_ok_extra_annotations.json')) as expected_data:
+            with open(os.path.join(self.TEST_CONFIG_FILES_PATH, 'teams_alert_all_ok_extra_annotations.json')) as expected_data:
                json_received = json.load(json_data)
                json_expected = json.load(expected_data)
 
                alerts = MessageSchema(exclude_annotations=excluded_annotations).load(json_received)
-               rendered_data = AlarmSender()._create_alarms(alerts)[0]
+               rendered_data = AlertSender()._create_alerts(alerts)[0]
                json_rendered = json.loads(rendered_data)
 
                diff = DeepDiff(json_rendered, json_expected, ignore_order=True)
@@ -115,12 +115,12 @@ class TestJSONFields(unittest.TestCase):
 
     def test_with_too_long_payload(self):
         with open(os.path.join(self.TEST_CONFIG_FILES_PATH, 'all_ok_multiple.json')) as json_data:
-            with open(os.path.join(self.TEST_CONFIG_FILES_PATH, 'teams_alarm_all_ok_splited.json')) as expected_data:
+            with open(os.path.join(self.TEST_CONFIG_FILES_PATH, 'teams_alert_all_ok_splitted.json')) as expected_data:
                 json_received = json.load(json_data)
                 json_expected = json.load(expected_data)
 
                 alerts = MessageSchema().load(json_received)
-                rendered_data = '[' + ','.join([a.replace("\n\n\n", " ") for a in AlarmSender(group_alerts_by='name', teams_client_config={'MAX_PAYLOAD': 800})._create_alarms(alerts)]) + ']'
+                rendered_data = '[' + ','.join([a.replace("\n\n\n", " ") for a in AlertSender(group_alerts_by='name', teams_client_config={'MAX_PAYLOAD': 800})._create_alerts(alerts)]) + ']'
                 json_rendered = json.loads(rendered_data)
 
                 diff = DeepDiff(json_rendered, json_expected, ignore_order=True)


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions
* Remember to set **idealista:develop** as base branch;

### Description of the Change

Code base should use the ubiquitous term "Alert" instead of "Alarm".

### Benefits

Improves code symmetry and uses ubiquitious language

### Possible Drawbacks

Afaik there aren't (I ran unit tests and e2e tests and works fine)

### Applicable Issues

#155
