### PR TITLE
[REFACTOR] Change travis-ci.org to travis-ci.com in README #244

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <div align="center">
   <img alt="logo" src="https://raw.githubusercontent.com/idealista/prom2teams/master/logo.gif">
 
-  [![Build Status](https://travis-ci.org/idealista/prom2teams.svg?branch=master)](https://travis-ci.org/idealista/prom2teams)
+  [![Build Status](https://travis-ci.com/idealista/prom2teams.svg?branch=master)](https://travis-ci.com/idealista/prom2teams)
   [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=idealista_prom2teams&metric=alert_status)](https://sonarcloud.io/dashboard?id=idealista_prom2teams)
   [![Docker Build Status](https://img.shields.io/docker/build/idealista/prom2teams.svg)](https://hub.docker.com/r/idealista/prom2teams/) 
   [![Docker Hub Pulls](https://img.shields.io/docker/pulls/idealista/prom2teams.svg)](https://hub.docker.com/r/idealista/prom2teams/)


### PR DESCRIPTION
### Description of the Change

Changed every occurence of `travis-ci.org` to `travis-ci.com` in the project's README file


### Benefits

When `travis-ci.org` migrates to the `.com` domain the links on the README doc will still work

### Possible Drawbacks

None

### Applicable Issues

#244 
