### PR TITLE
Remove python 3.5 from travis matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ services:
   - docker
 
 python:
-  - '3.5'
   - '3.6'
   - '3.7'
   - '3.8'

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,6 @@ setup(name='prom2teams',
         'Intended Audience :: System Administrators',
         'Topic :: System :: Monitoring',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8'


### PR DESCRIPTION
### Description of the Change

Python 3.5 is not compatible with current get-pip.py and fails trying to publish to PyPi

### Benefits

It's possible to plublish new versions ;)

### Possible Drawbacks

Python 3.5 compatibility not tested