### PR TITLE
#250 Fix error when alert has not fingerprint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a changelog](https://github.com/olivierlacan/keep-a-changelog).
 
 ## [Unreleased](https://github.com/idealista/prom2teams/tree/develop)
+### Fixed
+- *[#225](https://github.com/idealista/prom2teams/issues/250) Fix error when fingerprint is missing @jperera
+### Changed
+- *[#244](https://github.com/idealista/prom2teams/issues/244) Change travis-ci.org by travis-ci.com in README @Crozzers
 ## [3.2.0](https://github.com/idealista/prom2teams/tree/3.2.0)
 [Full Changelog](https://github.com/idealista/prom2teams/compare/3.1.0...3.2.0)
 ### Added

--- a/prom2teams/prometheus/message_schema.py
+++ b/prom2teams/prometheus/message_schema.py
@@ -40,7 +40,7 @@ class MessageSchema(Schema):
             description = alert['annotations']['description']
             severity = alert['labels']['severity']
             runbook_url = alert['annotations'].get('runbook_url', '')
-            fingerprint = alert.get('fingerprint', None)
+            fingerprint = alert.get('fingerprint', '')
             extra_labels = dict()
             extra_annotations = dict()
 

--- a/tests/data/json_files/teams_without_fingerprint.json
+++ b/tests/data/json_files/teams_without_fingerprint.json
@@ -1,0 +1,27 @@
+{
+  "@type": "MessageCard",
+  "@context": "http://schema.org/extensions",
+  "themeColor": " 2DC72D ",
+  "summary": "(Resolved) Disk usage alert on CS30.evilcorp",
+  "title": "Prometheus alert (Resolved) ",
+  "sections": [{
+    "activityTitle": "Disk usage alert on CS30.evilcorp",
+    "facts": [{
+      "name": "Alert",
+      "value": "DiskSpace"
+    },{
+      "name": "In host",
+      "value": "cs30.evilcorp"
+    },{
+      "name": "Severity",
+      "value": "severe"
+    },{
+      "name": "Description",
+      "value": "disk usage 93% on rootfs device"
+    },{
+      "name": "Status",
+      "value": "resolved"
+    }],
+    "markdown": true
+  }]
+}

--- a/tests/data/json_files/without_fingerprint.json
+++ b/tests/data/json_files/without_fingerprint.json
@@ -1,0 +1,26 @@
+{
+  "receiver": "test_webhook",
+  "status": "resolved",
+  "alerts": [
+    {
+      "status": "resolved",
+      "labels": {
+        "alertname": "DiskSpace",
+        "device": "rootfs",
+        "fstype": "rootfs",
+        "instance": "cs30.evilcorp",
+        "mountpoint": "/",
+        "severity": "severe"
+      },
+      "annotations": {
+        "description": "disk usage 93% on rootfs device",
+        "summary": "Disk usage alert on CS30.evilcorp"
+      },
+      "startsAt": "2017-05-09T07:01:37.803000Z",
+      "endsAt": "2017-05-09T07:08:37.818278Z",
+      "generatorURL": "my.prometheusserver.url"
+    }
+  ],
+  "externalURL": "my.prometheusalertmanager.url",
+  "version": "4"
+}

--- a/tests/test_json_fields.py
+++ b/tests/test_json_fields.py
@@ -46,6 +46,18 @@ class TestJSONFields(unittest.TestCase):
             alert = map_prom_alerts_to_teams_alerts(alerts)[0]
             self.assertEqual('dd19ae3d4e06ac55', str(alert['fingerprint']))
 
+    def test_without_fingerprint(self):
+        with open(os.path.join(self.TEST_CONFIG_FILES_PATH, 'without_fingerprint.json')) as json_data:
+            with open(os.path.join(self.TEST_CONFIG_FILES_PATH, 'teams_without_fingerprint.json')) as expected_data:
+                json_received = json.load(json_data)
+                json_expected = json.load(expected_data)
+
+                alerts = MessageSchema().load(json_received)
+                rendered_data = AlertSender()._create_alerts(alerts)[0]
+                json_rendered = json.loads(rendered_data)
+
+                self.assertEqual(json_rendered.keys(), json_expected.keys())
+
     def test_compose_all(self):
         with open(os.path.join(self.TEST_CONFIG_FILES_PATH, 'all_ok.json')) as json_data:
             with open(os.path.join(self.TEST_CONFIG_FILES_PATH, 'teams_alert_all_ok.json')) as expected_data:


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions
* Remember to set **idealista:develop** as base branch;

### Description of the Change

When alert has not fingerprint, the default value of fingerprint is '' instead of None. None value causes an exception when the alert is preparing for sending to teams.

### Benefits

Fix a bug every alert whitout fingerprint (a lot of)

### Possible Drawbacks

AFAIK, no drawbacks

### Applicable Issues

https://github.com/idealista/prom2teams/issues/250
