### PR TITLE
call out the list of expected value for some fields  in the value.yaml file

### DIFF
--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -24,7 +24,10 @@ prom2teams:
   port: 8089
   connector:
   connectors: {}
+  # group_alerts_by can be one of
+  # ("name" | "description" | "instance" | "severity" | "status" | "summary" | "fingerprint" | "runbook_url")
   group_alerts_by:
+  # loglevel can be one of (DEBUG | INFO | WARNING | ERROR | CRITICAL)
   loglevel: INFO
   templatepath: /opt/prom2teams/helmconfig/teams.j2
   config: /opt/prom2teams/helmconfig/config.ini


### PR DESCRIPTION

### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

This PR adds some comments to the `value.yaml` file to call out the expected value for the fields `group_alerts_by` and `loglevel`.
 
### Benefits

Listing out those expected values right in the value.yaml file will help new users to avoid runtime errors caused by misconfiguration. 

I hit the issue when I used prom2teams on my k8s cluster, and it took me almost one hour to figure out that the value of `group_alerts_by` must be one of "name" | "description" | "instance" | "severity" | "status" | "summary" | "fingerprint" | "runbook_url".  Those values are mentioned only once in the command under the `usage` section, which is easy to be missed. 

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks

no drawbacks
<!-- What are the possible side-effects or negative impacts of the code change? -->

### Applicable Issues

<!-- Enter any applicable Issues here -->
