### PR TITLE
Support venv installation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(name='prom2teams',
       },
       include_package_data=True,
       data_files=[
-          ('/usr/local/etc/prom2teams', ['bin/wsgi.py'])
+          (os.path.join(sys.prefix, 'etc/prom2teams'), ['bin/wsgi.py'])
       ],
       url='https://github.com/idealista/prom2teams',
       author='Idealista, S.A.U',


### PR DESCRIPTION
### Description of the Change

As mentioned in #262 - ```pip3 install prom2teams``` errors out in a [venv](https://docs.python.org/3/tutorial/venv.html) without write access to ```/usr/local/etc```.

This change uses [sys.prefix](https://docs.python.org/3/library/sys.html#sys.prefix) to get the path prefix - default is ```/usr/local```.

For venv use cases, sys.prefix will point to the virtual environment and ```<virtual_env>/etc/prom2teams/wsgi.py``` will be created.
<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->


### Benefits

Users in venv with read-only ```/usr/local/etc``` will be able to install prom2teams successfully.

### Possible Drawbacks

N/A

### Applicable Issues

#262  