### PR TITLE
Bump jinja & pyyaml versions avoiding CVEs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a changelog](https://github.com/olivierlacan/keep-a-changelog).
 
 ## [Unreleased](https://github.com/idealista/prom2teams/tree/develop)
+### Changed
+- Bump jinja2 and pyYAML versions @ablopez
+
 ## [3.2.1](https://github.com/idealista/prom2teams/tree/3.2.1)
 [Full Changelog](https://github.com/idealista/prom2teams/compare/3.2.0...3.2.1)
 ### Fixed

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
 requests==2.20.1
 flask-restplus==0.12.1
 marshmallow==3.0.0rc6
-jinja2==2.10.1
+jinja2==2.11.3
 Flask==1.0.2
-pyyaml==5.1
+pyyaml==5.4
 uwsgi==2.0.16
 prometheus_flask_exporter==0.9.0
 werkzeug==0.16.1


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions
* Remember to set **idealista:develop** as base branch;

### Description of the Change

Bump dependencies to avoid the following CVEs:

https://github.com/advisories/GHSA-g3rq-g295-4j3m
https://github.com/advisories/GHSA-3pqx-4fqf-j49f
https://github.com/advisories/GHSA-6757-jp84-gxfx
https://github.com/advisories/GHSA-8q59-q68h-6hv4


### Benefits

Solve CVEs

### Possible Drawbacks

None AFAIK (all updated versions are minor versions)

### Applicable Issues

N/A
