### PR TITLE
add helm chart servicemonitor resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a changelog](https://github.com/olivierlacan/keep-a-changelog).
 
 ## [Unreleased](https://github.com/idealista/prom2teams/tree/develop)
+### Added
+- Add servicemonitor resource and metrics sharing to helm-chart
 
 ## [3.2.3](https://github.com/idealista/prom2teams/tree/3.2.3)
 [Full Changelog](https://github.com/idealista/prom2teams/compare/3.2.2...3.2.3)

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "3.2.3"
 description: A Helm chart for Prom2Teams
 name: prom2teams
-version: 0.2.0
+version: 0.2.1

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -46,6 +46,10 @@ spec:
             value: {{ .Values.prom2teams.connector | quote }}
           - name: PROM2TEAMS_GROUP_ALERTS_BY
             value: {{ .Values.prom2teams.group_alerts_by | quote }}
+          {{- if .Values.servicemonitor.enabled }}
+          - name: PROM2TEAMS_PROMETHEUS_METRICS
+            value: "true"
+          {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
         {{- if .Values.securityContext.enabled }}

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -46,10 +46,8 @@ spec:
             value: {{ .Values.prom2teams.connector | quote }}
           - name: PROM2TEAMS_GROUP_ALERTS_BY
             value: {{ .Values.prom2teams.group_alerts_by | quote }}
-          {{- if .Values.servicemonitor.enabled }}
           - name: PROM2TEAMS_PROMETHEUS_METRICS
-            value: "true"
-          {{- end }}
+            value: {{ .Values.prom2teams.prometheus_metrics_enabled | quote }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
         {{- if .Values.securityContext.enabled }}

--- a/helm/templates/servicemonitor.yaml
+++ b/helm/templates/servicemonitor.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.servicemonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "prom2teams.fullname" . }}
+  labels: 
+{{ include "prom2teams.labels" . | indent 4 }}
+spec:
+  selector:
+    matchLabels: 
+{{ include "prom2teams.labels" . | indent 6 }}
+  endpoints:
+    - port: http
+      path: "/metrics"
+      {{- if .Values.servicemonitor.interval }}
+      interval: {{ .Values.servicemonitor.interval }}
+      {{- end }}
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+{{- end }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -44,3 +44,10 @@ securityContext:
   fsGroup: 65534
   # readOnlyRootFilesystem is a flag to enable readOnlyRootFilesystem for the Hazelcast security context
   readOnlyRootFilesystem: true
+
+# Service Monitor properties
+servicemonitor:
+  # enabled is a flag to enable Service Monitor resource 
+  enabled: false
+  # interval is the Service Monitor scrape interval to scrape metrics
+  interval: 15s

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -31,6 +31,7 @@ prom2teams:
   loglevel: INFO
   templatepath: /opt/prom2teams/helmconfig/teams.j2
   config: /opt/prom2teams/helmconfig/config.ini
+  prometheus_metrics_enabled: false
 
 # Security Context properties
 securityContext:
@@ -47,7 +48,8 @@ securityContext:
 
 # Service Monitor properties
 servicemonitor:
-  # enabled is a flag to enable Service Monitor resource 
+  # enabled is a flag to enable Service Monitor resource
+  # You should also set prom2teams.prometheus_metrics_enabled: true
   enabled: false
   # interval is the Service Monitor scrape interval to scrape metrics
   interval: 15s


### PR DESCRIPTION
### Requirements

Deployed [prometheus-operator](https://github.com/prometheus-operator/prometheus-operator) in your kubernetes cluster.

### Description of the Change

- added a _ServiceMonitor_ Resource for the prometheus-operator
- expose Metrics when _ServiceMonitor_ is enabled
- option in `values.yaml` to enable _ServiceMonitor_ (disabled by default)

### Benefits

Built-in Support for a _ServiceMonitor_, which enables automatic configuring of the metric endpoint for metric scraping

### Possible Drawbacks

Not known, as the added resource remains disabled by default.

### Applicable Issues

<!-- Enter any applicable Issues here -->
