### PR TITLE
Allow to add arbitrary envvars to deployment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a ch
 ## [Unreleased](https://github.com/idealista/prom2teams/tree/develop)
 ### Fixed
 - *[#279](https://github.com/idealista/prom2teams/pull/279) Fixed issue with MS Teams exception handling* @nryabkov
+### Added
+- *[#281](https://github.com/idealista/prom2teams/pull/281) Allow to add arbitrary envvars to deployment* @dkobras
 
 ## [3.2.3](https://github.com/idealista/prom2teams/tree/3.2.3)
 [Full Changelog](https://github.com/idealista/prom2teams/compare/3.2.2...3.2.3)

--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ The following table lists the configurable parameters of the Prom2teams chart an
 | `prom2teams.loglevel`                           | Loglevel                                                                                                           | `INFO`
 | `prom2teams.templatepath`                       | Custom Template path (files/teams.j2)                                                                              | `/opt/prom2teams/helmconfig/teams.j2`
 | `prom2teams.config`                             | Config (specific to Helm)                                                                                          | `/opt/prom2teams/helmconfig/config.ini`
+| `prom2teams.extraEnv`                           | Dictionary of arbitrary additional environment variables for deployment (eg. `HTTP_PROXY`)                         | `<empty>`
 
 ### Production
 

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -46,6 +46,10 @@ spec:
             value: {{ .Values.prom2teams.connector | quote }}
           - name: PROM2TEAMS_GROUP_ALERTS_BY
             value: {{ .Values.prom2teams.group_alerts_by | quote }}
+          {{- range $key, $value := .Values.prom2teams.extraEnv }}
+          - name: "{{ $key }}"
+            value: "{{ $value }}"
+          {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
         {{- if .Values.securityContext.enabled }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -31,6 +31,7 @@ prom2teams:
   loglevel: INFO
   templatepath: /opt/prom2teams/helmconfig/teams.j2
   config: /opt/prom2teams/helmconfig/config.ini
+  extraEnv: {}
 
 # Security Context properties
 securityContext:


### PR DESCRIPTION
### Requirements

No additional requirements are introduced by this change.

### Description of the Change

Extend helm templates to allow to specify additional arbitrary environment variables to be passed to deployment.

### Benefits

Allow further customization of deployment from Helm template. For example, if teams server can only be reached via a proxy, variables `HTTP_PROXY` and/or `HTTPS_PROXY` can be configured via the newly introduced prom2teams.extraEnv helm setting.

### Possible Drawbacks

New setting is optional, hence no drawbacks.

### Applicable Issues

Feature has been requested in issue #239 (already closed due to inactivity)