### PR TITLE
#228 Fixed .travis.yml config file to solve warnings when triggering TravisCI builds.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+os: linux
+dist: xenial
 language: python
 
 services:
@@ -33,9 +35,8 @@ jobs:
     - stage: Deploy to PyPI
       script: skip
       deploy:
-        skip_cleanup: true
         provider: pypi
-        user: idealista
+        username: idealista
         password:
           secure: vGEjnrN5N3KlYHA/3LC+uJpW2lr1sZCUahNz0OjycNg/oKB1CZuQx0TuiXF/i8DnqnYpfW+tpFEjSwa2TqJIKhrQFf9yLUblr/Ky9H8VXzyLWI+DN3t3EbCg9QWRGuC7RJm57PZkjfMR6RewHNqpjAlzkRE4kLP7CItJYJNOapXDpUIGccPucubprPs0AGL0roNG8fhs9goyeHD05es6OCS1v1LO9j91mDMno+XH2yNwSFmVHRFbzdZP+jHqx8L4dI+mlOIK2iATW1JTCyGWRHBqfb8w7Pi97r4qWpl76OduFH8b6Ldg5adIFgXFzyTUpZUNmenFLji9FwxXUWTQHCtRWzSx6SfN1ebaaqyCA84+p12pEXXee2xLhw04pWLrHHk22FnleEcL+Us80s50+lWCZz0MiakyTCVE+0YJuW/CT25RNGZvOvtrqyZCXFi2OO2Nu8NIbCKjvehNKpXCFdJLBBJcUAOmNz667ELEs8OTzFqxzJwykkxW+zwvxNc3/T5P1v1q8lUbxml3qSKfzvmyirXH1v0D/GMXuQdDqw3oBdjJb304bSsiWJ0l1YCYRkl7fV9bnO0WboEqJG6HJGX3Pt1GgQIrIu/DnBZOnUiSFwaqH4nh1pyYzEHqTAxPsmIaVtYkTgJOkoZXZLtLv0CefB5jo3SmLF1g3qGDRCc=
         on:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,15 @@
 os: linux
-dist: xenial
+dist: bionic
 language: python
 
 services:
   - docker
 
 python:
-  - '3.6'
   - '3.7'
   - '3.8'
+  - '3.9'
+  - '3.10'
 
 env:
   - DOCKER_COMPOSE_VERSION=1.27.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ python:
   - '3.7'
   - '3.8'
   - '3.9'
-  - '3.10'
 
 env:
   - DOCKER_COMPOSE_VERSION=1.27.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a ch
 
 ## [Unreleased](https://github.com/idealista/prom2teams/tree/develop)
 ### Fixed
+- *[#290](https://github.com/idealista/prom2teams/pull/290) Fixed .travis.yml config file to solve warnings when triggering TravisCI builds.* @ommarmol
 - *[#279](https://github.com/idealista/prom2teams/pull/279) Fixed issue with MS Teams exception handling* @nryabkov
 ### Added
 - *[#281](https://github.com/idealista/prom2teams/pull/281) Allow to add arbitrary envvars to deployment* @dkobras

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a ch
 
 ## [Unreleased](https://github.com/idealista/prom2teams/tree/develop)
 ### Fixed
-- *[#290](https://github.com/idealista/prom2teams/pull/290) Fixed .travis.yml config file to solve warnings when triggering TravisCI builds.* @ommarmol
+- *[#290](https://github.com/idealista/prom2teams/pull/290) Fixed .travis.yml config file and added to requirements.txt some missing dependencies.* @ommarmol
 - *[#279](https://github.com/idealista/prom2teams/pull/279) Fixed issue with MS Teams exception handling* @nryabkov
 ### Added
 - *[#281](https://github.com/idealista/prom2teams/pull/281) Allow to add arbitrary envvars to deployment* @dkobras

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ zipp==1.2.0
 MarkupSafe==1.1.1
 pyrsistent==0.16.0
 tenacity==6.2.0
+itsdangerous==2.0.1


### PR DESCRIPTION
<!--

Have you read Idealista's Code of Conduct? By filling an Issue, you are expected to comply with it,
 including treating everyone with respect: https://github.com/idealista/prom2teams/blob/master/CODE_OF_CONDUCT.md

-->

### Prerequisites

* [x] Put an X between the brackets on this line if you have done all of the following:
    * Checked that your issue isn't already filled: https://github.com/issues?utf8=✓&q=is%3Aissue+user%3Aidealista
    * Checked that there is not already provided the described functionality

### Description

There are some warnings when a build is triggered in Travis: 

<img width="632" alt="Captura de pantalla 2020-10-28 a las 10 30 26" src="https://user-images.githubusercontent.com/1285260/97418074-ab577380-1908-11eb-8727-7222056ac962.png">

### Additional Information

Any additional information, configuration or data that might be necessary to reproduce the issue.
