### PR TITLE
Add Github Action to publish Helm chart

### DIFF
--- a/.github/workflows/release-chart.yml
+++ b/.github/workflows/release-chart.yml
@@ -1,0 +1,27 @@
+name: Release chart
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - "helm/**"
+jobs:
+  release-chart:
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+      - name: Run chart-releaser
+        uses: helm/chart-releaser-action@v1.4.0
+        with:
+          charts_dir: ./
+        env:
+          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a ch
 - *[#279](https://github.com/idealista/prom2teams/pull/279) Fixed issue with MS Teams exception handling* @nryabkov
 ### Added
 - *[#281](https://github.com/idealista/prom2teams/pull/281) Allow to add arbitrary envvars to deployment* @dkobras
+- *[#291](https://github.com/idealista/prom2teams/pull/291) Publish the helm chart in self-hosted repo using Github Pages* @chrissng
 
 ## [3.2.3](https://github.com/idealista/prom2teams/tree/3.2.3)
 [Full Changelog](https://github.com/idealista/prom2teams/compare/3.2.2...3.2.3)

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
   [![Build Status](https://travis-ci.com/idealista/prom2teams.svg?branch=master)](https://travis-ci.com/idealista/prom2teams)
   [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=idealista_prom2teams&metric=alert_status)](https://sonarcloud.io/dashboard?id=idealista_prom2teams)
-  [![Docker Build Status](https://img.shields.io/docker/build/idealista/prom2teams.svg)](https://hub.docker.com/r/idealista/prom2teams/) 
+  [![Docker Build Status](https://img.shields.io/docker/build/idealista/prom2teams.svg)](https://hub.docker.com/r/idealista/prom2teams/)
   [![Docker Hub Pulls](https://img.shields.io/docker/pulls/idealista/prom2teams.svg)](https://hub.docker.com/r/idealista/prom2teams/)
 </div>
 
@@ -99,12 +99,35 @@ $ docker run -it -d -v pathToTheLocalConfigFile:/opt/prom2teams/config.ini -p 80
 
 ### Helm chart
 
-#### Installing the Chart
+#### Chart repository
+
+The chart is published as a repository using GitHub Pages at https://idealista.github.io/prom2teams.
+
+Add the chart repository:
+```bash
+helm repo add prom2teams https://idealista.github.io/prom2teams
+```
+
+List published charts:
+```bash
+helm repo update
+helm search repo -l prom2teams/prom2teams
+```
+
+#### Installing the Chart from local path
 
 To install the chart with the release name `my-release` run:
 
 ```bash
-$ helm install --name my-release /location/of/prom2teams_ROOT/helm
+$ helm install  my-release prom2teams/prom2teams --version 0.2.0
+```
+
+#### Installing the Chart from local path
+
+To install the chart with the release name `my-release` run:
+
+```bash
+$ helm install my-release /location/of/prom2teams_ROOT/helm
 ```
 
 After a few seconds, Prom2Teams should be running.
@@ -201,7 +224,7 @@ The config file is an [INI file](https://docs.python.org/3/library/configparser.
 [Microsoft Teams]
 # At least one connector is required here
 Connector: <webhook url>
-AnotherConnector: <webhook url>   
+AnotherConnector: <webhook url>
 ...
 
 [HTTP Server]
@@ -238,7 +261,7 @@ The [webhook receiver](https://prometheus.io/docs/alerting/configuration/#<webho
 
 The url is formed by the host and port defined in the previous step.
 
-**Note:** In order to keep compatibility with previous versions, v2.0 keep attending the default connector ("Connector") in the endpoint 0.0.0.0:8089. This will be removed in future versions.   
+**Note:** In order to keep compatibility with previous versions, v2.0 keep attending the default connector ("Connector") in the endpoint 0.0.0.0:8089. This will be removed in future versions.
 
 ```
 // The prom2teams endpoint to send HTTP POST requests to.


### PR DESCRIPTION
### Description of the Change

Add Github Action workflow to publish the helm chart in self-hosted repo using Github Pages.
* Workflow runs on push to `master` branch if there are any changes to `helm/` directory.
* The workflow run will look like this: https://github.com/chrissng/prom2teams/runs/6399970552?check_suite_focus=true
* The self-hosted chart repo will look like this: https://chrissng.github.io/prom2teams/index.yaml

### Benefits

Easier to deploy prom2teams as a helm chart using tooling such as Terraform, ArgoCD, etc. as it is easier to access it via chart repo.

### Possible Drawbacks

Some [prerequisite steps](https://github.com/helm/chart-releaser-action#pre-requisites) are required to initialize the `gh-pages` branch, e.g. https://gist.github.com/ramnathv/2227408

### Applicable Issues

N/A
