### PR TITLE
Add PROM2TEAMS_TEMPLATEPATH environment variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a changelog](https://github.com/olivierlacan/keep-a-changelog).
 
 ## [Unreleased](https://github.com/idealista/prom2teams/tree/develop)
+### Added
+- `PROM2TEAMS_TEMPLATEPATH` environment variable
+
 ## [4.0.0](https://github.com/idealista/prom2teams/tree/4.0.0)
 [Full Changelog](https://github.com/idealista/prom2teams/compare/3.3.0...4.0.0)
 ### Fixed

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,7 @@ ENV PROM2TEAMS_PORT="8089" \
         PROM2TEAMS_LOGLEVEL="INFO" \
         PROM2TEAMS_CONNECTOR="" \
         PROM2TEAMS_GROUP_ALERTS_BY="" \
+        PROM2TEAMS_TEMPLATEPATH="/opt/prom2teams/helmconfig/teams.j2" \
         APP_CONFIG_FILE="/opt/prom2teams/config.ini" \
         PROM2TEAMS_PROMETHEUS_METRICS="true" \
         UWSGI_PROCESSES="1" \

--- a/docker/rootfs/config.ini
+++ b/docker/rootfs/config.ini
@@ -10,3 +10,6 @@ Field: prom2teamsgroupalertsby
 
 [Log]
 Level: prom2teamslogslevel
+
+[Template]
+Path: prom2teamstemplatepath

--- a/docker/rootfs/replace_config.py
+++ b/docker/rootfs/replace_config.py
@@ -9,6 +9,7 @@ filedata = filedata.replace("prom2teamshost", os.environ.get("PROM2TEAMS_HOST"))
 filedata = filedata.replace("prom2teamsconnector", os.environ.get("PROM2TEAMS_CONNECTOR"))
 filedata = filedata.replace("prom2teamsgroupalertsby", os.environ.get("PROM2TEAMS_GROUP_ALERTS_BY"))
 filedata = filedata.replace("prom2teamslogslevel", os.environ.get("PROM2TEAMS_LOGLEVEL"))
+filedata = filedata.replace("prom2teamstemplatepath", os.environ.get("PROM2TEAMS_TEMPLATEPATH"))
 
 with open('/opt/prom2teams/config.ini', 'w') as file:
   file.write(filedata)

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -52,6 +52,8 @@ spec:
           - name: "{{ $key }}"
             value: "{{ $value }}"
           {{- end }}
+          - name: PROM2TEAMS_TEMPLATEPATH
+            value: {{ .Values.prom2teams.templatepath | quote  }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
         {{- if .Values.securityContext.enabled }}


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions
* Remember to set **idealista:develop** as base branch;

### Description of the Change

Add `PROM2TEAMS_TEMPLATEPATH` environment variable to set the template path

### Benefits

Set the template path via the env variable


### Possible Drawbacks

None

### Applicable Issues


