### PR TITLE
#309 fix metrics in UWsgi mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a changelog](https://github.com/olivierlacan/keep-a-changelog).
 
 ## [Unreleased](https://github.com/idealista/prom2teams/tree/develop)
+## [4.1.0](https://github.com/idealista/prom2teams/tree/4.1.0)
+[Full Changelog](https://github.com/idealista/prom2teams/compare/4.0.0...4.1.0)
+### Fixed
+- *[#309](https://github.com/idealista/prom2teams/pull/309) Update prom2teams to use flask exporter with uWSGI for metrics when using uWSGI mode* @santi-eidu
 ## [4.0.0](https://github.com/idealista/prom2teams/tree/4.0.0)
 [Full Changelog](https://github.com/idealista/prom2teams/compare/3.3.0...4.0.0)
 ### Fixed

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ RUN apk add gcc libc-dev yaml-dev linux-headers --no-cache \
 FROM python:3.8-alpine
 LABEL maintainer="labs@idealista.com"
 EXPOSE 8089
+EXPOSE 9090
 WORKDIR /opt/prom2teams
 COPY docker/rootfs .
 COPY --from=builder /prom2teams/dist .
@@ -23,6 +24,7 @@ RUN apk add gcc libc-dev yaml-dev linux-headers pcre pcre-dev --no-cache \
 RUN addgroup -g "101" -S prom2teams && \
         adduser -S prom2teams -G prom2teams -u "101" && \
         mkdir -p /var/log/prom2teams && \
+        mkdir -p /opt/prom2teams/metrics && \
         chown -R prom2teams:prom2teams /var/log/prom2teams && \
         chown -R prom2teams:prom2teams /opt/prom2teams
 USER prom2teams
@@ -37,5 +39,8 @@ ENV PROM2TEAMS_PORT="8089" \
         UWSGI_THREADS="1" \
         UWSGI_PORT="8089" \
         UWSGI_HOST="0.0.0.0" \
-        UWSGI_PROTOCOL="http" 
+        UWSGI_PROTOCOL="http" \
+        PROMETHEUS_MULTIPROC_PORT="9090" \
+        PROMETHEUS_MULTIPROC_DIR="/opt/prom2teams/metrics" \
+        prometheus_multiproc_dir="/opt/prom2teams/metrics"
 ENTRYPOINT ["sh", "prom2teams_start.sh"]

--- a/bin/prom2teams
+++ b/bin/prom2teams
@@ -10,6 +10,7 @@ except ImportError:
     from prom2teams.app.api import app as application
 
 if __name__ == "__main__":
+    application.config['ENV'] = "werkzeug"
     host = application.config['HOST']
     port = int(application.config['PORT'])
     run_simple(hostname=host, port=port, application=application, use_reloader=True,

--- a/prom2teams/app/configuration.py
+++ b/prom2teams/app/configuration.py
@@ -130,9 +130,13 @@ def config_app(application):
             application.config['GROUP_ALERTS_BY'] = command_line_args.groupalertsby
         if command_line_args.enablemetrics or os.environ.get('PROM2TEAMS_PROMETHEUS_METRICS', False):
             os.environ["DEBUG_METRICS"] = "True"
-            from prometheus_flask_exporter.multiprocess import UWsgiPrometheusMetrics
-            metrics = UWsgiPrometheusMetrics(application)
-            metrics.start_http_server(int(os.getenv('PROMETHEUS_MULTIPROC_PORT')))
+            if application.config['ENV'] == "werkzeug":
+                from prometheus_flask_exporter import PrometheusMetrics
+                metrics = PrometheusMetrics(application)
+            else:
+                from prometheus_flask_exporter.multiprocess import UWsgiPrometheusMetrics
+                metrics = UWsgiPrometheusMetrics(application)
+                metrics.start_http_server(int(os.getenv('PROMETHEUS_MULTIPROC_PORT')))
         if 'MICROSOFT_TEAMS' not in application.config:
             raise MissingConnectorConfigKeyException('missing connector key in config')
 

--- a/prom2teams/app/configuration.py
+++ b/prom2teams/app/configuration.py
@@ -130,9 +130,9 @@ def config_app(application):
             application.config['GROUP_ALERTS_BY'] = command_line_args.groupalertsby
         if command_line_args.enablemetrics or os.environ.get('PROM2TEAMS_PROMETHEUS_METRICS', False):
             os.environ["DEBUG_METRICS"] = "True"
-            from prometheus_flask_exporter import PrometheusMetrics
-            metrics = PrometheusMetrics(application)
-
+            from prometheus_flask_exporter.multiprocess import UWsgiPrometheusMetrics
+            metrics = UWsgiPrometheusMetrics(application)
+            metrics.start_http_server(int(os.getenv('PROMETHEUS_MULTIPROC_PORT')))
         if 'MICROSOFT_TEAMS' not in application.config:
             raise MissingConnectorConfigKeyException('missing connector key in config')
 


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions
* Remember to set **idealista:develop** as base branch;

### Description of the Change

Change prometheus metrics function to use Uwsgi with the variable prometheus_multiproc_dir to store the metrics.

### Benefits

Metrics share a directory with metrics info.

### Possible Drawbacks

No wsgi modes can be affected

### Applicable Issues

#309 
