### PR TITLE
refactoring of helm chart:

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "4.2.0"
 description: A Helm chart for Prom2Teams
 name: prom2teams
-version: 0.2.0
+version: 0.3.0

--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -35,12 +35,18 @@ Create chart name and version as used by the chart label.
 Common labels
 */}}
 {{- define "prom2teams.labels" -}}
-app.kubernetes.io/name: {{ include "prom2teams.name" . }}
 helm.sh/chart: {{ include "prom2teams.chart" . }}
-app.kubernetes.io/instance: {{ .Release.Name }}
-release: {{ .Release.Name }}
+{{ include "prom2teams.selectorLabels" . }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end -}}
+
+{{/*
+Selector labels
+*/}}
+{{- define "prom2teams.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "prom2teams.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/helm/templates/configmap.yaml
+++ b/helm/templates/configmap.yaml
@@ -11,10 +11,9 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: prom2teams-config
+  name: {{ include "prom2teams.fullname" . }}
   labels:
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
+    {{ include "prom2teams.labels" . | nindent 4 }}
 data:
   config.ini: |-
     [HTTP Server]

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -3,34 +3,40 @@ kind: Deployment
 metadata:
   name: {{ include "prom2teams.fullname" . }}
   labels:
-{{ include "prom2teams.labels" . | indent 4 }}
+    {{- include "prom2teams.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels:
-      app.kubernetes.io/name: {{ include "prom2teams.name" . }}
-      app.kubernetes.io/instance: {{ .Release.Name }}
+      {{- include "prom2teams.selectorLabels" . | nindent 6 }}
   template:
     metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       labels:
-        app.kubernetes.io/name: {{ include "prom2teams.name" . }}
-        app.kubernetes.io/instance: {{ .Release.Name }}
+        {{- include "prom2teams.selectorLabels" . | nindent 8 }}
     spec:
-    {{- with .Values.imagePullSecrets }}
+      {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
-    {{- end }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
       volumes:
         - name: config
           configMap:
-            name: prom2teams-config
+            name: {{ include "prom2teams.fullname" . }}
       containers:
         - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ default .Chart.AppVersion .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: http
-              containerPort: 8089
+              containerPort: {{ .Values.service.port }}
               protocol: TCP
           volumeMounts:
             - name: config
@@ -48,38 +54,31 @@ spec:
             value: {{ .Values.prom2teams.group_alerts_by | quote }}
           - name: PROM2TEAMS_LOGLEVEL
             value: {{ .Values.prom2teams.loglevel }}
+          - name: PROM2TEAMS_PROMETHEUS_METRICS
+            value: {{ .Values.prom2teams.metrics | quote }}
           {{- range $key, $value := .Values.prom2teams.extraEnv }}
           - name: "{{ $key }}"
             value: "{{ $value }}"
           {{- end }}
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
-        {{- if .Values.securityContext.enabled }}
-          securityContext:
-            privileged: false
-            readOnlyRootFilesystem: false
-            allowPrivilegeEscalation: false
-            capabilities:
-              drop:
-              - ALL
-        {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-    {{- with .Values.affinity }}
+      {{- with .Values.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}
-    {{- end }}
-    {{- with .Values.tolerations }}
+      {{- end }}
+      {{- with .Values.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
-    {{- end }}
-    {{- if .Values.securityContext.enabled }}
-      securityContext:
-        runAsNonRoot: {{ if eq (int .Values.securityContext.runAsUser) 0 }}false{{ else }}true{{ end }}
-        runAsUser: {{ .Values.securityContext.runAsUser }}
-        runAsGroup: {{ .Values.securityContext.runAsGroup }}
-        fsGroup: {{ .Values.securityContext.fsGroup }}
-    {{- end }}
-
+      {{- end }}

--- a/helm/templates/service.yaml
+++ b/helm/templates/service.yaml
@@ -4,6 +4,10 @@ metadata:
   name: {{ include "prom2teams.fullname" . }}
   labels:
 {{ include "prom2teams.labels" . | indent 4 }}
+{{- if .Values.service.annotations }}
+  annotations:
+{{ toYaml .Values.service.annotations | indent 4 }}
+{{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:
@@ -12,5 +16,4 @@ spec:
       protocol: TCP
       name: http
   selector:
-    app.kubernetes.io/name: {{ include "prom2teams.name" . }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
+    {{- include "prom2teams.selectorLabels" . | nindent 4 }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -18,10 +18,16 @@ resources:
 service:
   type: ClusterIP
   port: 8089
+#  annotations:
+#    prometheus.io/scrape: "true"
+#    prometheus.io/port: "8089"
+#    prometheus.io/scheme: http
+#    prometheus.io/path: /metrics
 
 prom2teams:
   host: 0.0.0.0
   port: 8089
+  metrics: false
   connector:
   connectors: {}
   # group_alerts_by can be one of
@@ -33,15 +39,19 @@ prom2teams:
   config: /opt/prom2teams/helmconfig/config.ini
   extraEnv: {}
 
-# Security Context properties
+podAnnotations: {}
+
 securityContext:
-  # enabled is a flag to enable Security Context
-  enabled: true
-  # runAsUser is the user ID used to run the container
+  privileged: false
+  readOnlyRootFilesystem: false
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
   runAsUser: 101
-  # runAsGroup is the primary group ID used to run all processes within any container of the pod
   runAsGroup: 101
-  # fsGroup is the group ID associated with the container
-  fsGroup: 101
-  # readOnlyRootFilesystem is a flag to enable readOnlyRootFilesystem for the Hazelcast security context
-  readOnlyRootFilesystem: true
+
+podSecurityContext:
+  fsGroup: 2000
+  seccompProfile:
+    type: RuntimeDefault


### PR DESCRIPTION
### Description of the Change
* add metrics parameter and service annotations for prometheus monitoring
* add pod annotation (not important but for pod annotations for prometheus monitoring)
* fix/move securityContext/podSecurityContext to values.yaml
* update selectorLabels (with default from helm create template)
* change hardcoded configmap to dynamic name
* move hardcoded service port to values.yaml
* update the chart version to 0.3.0

### Benefits
* More stability (health checks)
* parallel start of multiple pods (configmap no name conflict) in one namespace
* more the "standard" of helm charts (compared to current helm create <chartname>)
* fix of security settings/outsourcing to values.yaml: more flexibility
 