### PR TITLE
Handle unicode characters

### DIFF
--- a/prom2teams/app/teams_client.py
+++ b/prom2teams/app/teams_client.py
@@ -43,7 +43,7 @@ class TeamsClient:
             simple_post(teams_webhook_url, message)
 
     def _do_post(self, teams_webhook_url, message):
-        response = self.session.post(teams_webhook_url, data=message, timeout=self.timeout)
+        response = self.session.post(teams_webhook_url, data=message.encode('utf-8'), timeout=self.timeout)
         if response.status_code != 202 and (response.status_code != 200 or response.text != '1'):
             exception_msg = 'Error performing request to: {}.\n' \
                 ' Returned status code: {}.\n' \


### PR DESCRIPTION
### Description of the Change

Encode message to utf-8 so unicode characters can be sent to teams.
Without this we're seeing errors like this:
```
'latin-1' codec can't encode character '\\u0113' in position 1003: Body ('ē') is not valid Latin-1. Use body.encode('utf-8') if you want to send it encoded in UTF-8.
```
